### PR TITLE
feat(batch-14): S3 Object Lock (WORM) — 39 new tests passing (#142)

### DIFF
--- a/TEST-COVERAGE.md
+++ b/TEST-COVERAGE.md
@@ -698,6 +698,77 @@ test_get_checksum_object_attributes
 
 ---
 
+## feat/batch-14-object-lock — Batch 14: S3 Object Lock (WORM)
+
+**Branch:** `feat/batch-14-object-lock`
+**RFC Batch:** Batch 14 (RFC 2.6 — Object Lock)
+**Newly passing:** 39
+
+Key changes:
+- `object_lock` SQLite table: `(bucket, key, version_id, mode, retain_until_date, legal_hold)` with COALESCE upsert
+- `object_lock_config` table: bucket-level default retention `(bucket, mode, days, years)`
+- `buckets` table: `object_lock_enabled INTEGER` column; `create_bucket_with_lock` sets versioning=enabled automatically
+- `object_lock.rs`: 6 handlers — PUT/GET `?object-lock` (bucket config), PUT/GET `?retention`, PUT/GET `?legal-hold`
+- COMPLIANCE mode: blocks shortening retain_until_date or changing mode (no bypass possible)
+- GOVERNANCE mode: shortening or mode change requires `x-amz-bypass-governance-retention: true`; extending date freely allowed
+- `check_object_lock_protection`: called before every versioned delete (single and multi-delete)
+- Legal hold ON blocks delete regardless of retention; stored separately from retention via COALESCE
+- PutObject: reads `x-amz-object-lock-mode`, `x-amz-object-lock-retain-until-date`, `x-amz-object-lock-legal-hold` headers; falls back to bucket default retention config
+- HEAD/GET object: returns `x-amz-object-lock-mode`, `x-amz-object-lock-retain-until-date`, `x-amz-object-lock-legal-hold` headers
+- CreateMultipartUpload: stores lock headers; CompleteMultipartUpload applies them to final object
+- Legal hold header fix: boto3 uses `x-amz-object-lock-legal-hold` (not `-legal-hold-status`) for both request and response
+- GET routing: `?retention` and `?legal-hold` dispatch before `?versionId` (boto3 sends both params together)
+- Suspend versioning on object-lock bucket returns 409 InvalidBucketState
+- `multipart_uploads` table: added `object_lock_mode`, `object_lock_retain_until`, `object_lock_legal_hold` columns
+
+### Verified Passing (39)
+
+```
+test_object_lock_put_obj_lock
+test_object_lock_put_obj_lock_invalid_bucket
+test_object_lock_put_obj_lock_enable_after_create
+test_object_lock_put_obj_lock_with_days_and_years
+test_object_lock_put_obj_lock_invalid_days
+test_object_lock_put_obj_lock_invalid_years
+test_object_lock_put_obj_lock_invalid_mode
+test_object_lock_put_obj_lock_invalid_status
+test_object_lock_suspend_versioning
+test_object_lock_get_obj_lock
+test_object_lock_get_obj_lock_invalid_bucket
+test_object_lock_put_obj_retention
+test_object_lock_put_obj_retention_invalid_bucket
+test_object_lock_put_obj_retention_invalid_mode
+test_object_lock_get_obj_retention
+test_object_lock_get_obj_retention_iso8601
+test_object_lock_get_obj_retention_invalid_bucket
+test_object_lock_put_obj_retention_versionid
+test_object_lock_put_obj_retention_override_default_retention
+test_object_lock_put_obj_retention_increase_period
+test_object_lock_put_obj_retention_shorten_period
+test_object_lock_put_obj_retention_shorten_period_bypass
+test_object_lock_delete_object_with_retention
+test_object_lock_delete_multipart_object_with_retention
+test_object_lock_delete_object_with_retention_and_marker
+test_object_lock_multi_delete_object_with_retention
+test_object_lock_put_legal_hold
+test_object_lock_put_legal_hold_invalid_bucket
+test_object_lock_put_legal_hold_invalid_status
+test_object_lock_get_legal_hold
+test_object_lock_get_legal_hold_invalid_bucket
+test_object_lock_delete_object_with_legal_hold_on
+test_object_lock_delete_multipart_object_with_legal_hold_on
+test_object_lock_delete_object_with_legal_hold_off
+test_object_lock_get_obj_metadata
+test_object_lock_uploading_obj
+test_object_lock_changing_mode_from_governance_with_bypass
+test_object_lock_changing_mode_from_governance_without_bypass
+test_object_lock_changing_mode_from_compliance
+```
+
+**Running total: 433 / 808**
+
+---
+
 <!-- Template for next entry — copy and fill in before each push:
 
 ## <branch-name> — <short description>

--- a/server/src/metadata/sqlite_store.rs
+++ b/server/src/metadata/sqlite_store.rs
@@ -114,9 +114,12 @@ lazy_static! {
                 initiated_at       TEXT NOT NULL,
                 status             TEXT NOT NULL DEFAULT 'in_progress',
                 final_etag         TEXT,
-                tagging            TEXT DEFAULT '',
-                checksum_algorithm TEXT NOT NULL DEFAULT '',
-                checksum_type      TEXT NOT NULL DEFAULT ''
+                tagging                TEXT DEFAULT '',
+                checksum_algorithm     TEXT NOT NULL DEFAULT '',
+                checksum_type          TEXT NOT NULL DEFAULT '',
+                object_lock_mode       TEXT NOT NULL DEFAULT '',
+                object_lock_retain_until TEXT NOT NULL DEFAULT '',
+                object_lock_legal_hold TEXT NOT NULL DEFAULT ''
             );
             CREATE TABLE IF NOT EXISTS multipart_parts (
                 upload_id       TEXT NOT NULL,
@@ -146,15 +149,41 @@ lazy_static! {
         // Bucket registry — tracks created buckets (including empty ones)
         conn.execute(
             "CREATE TABLE IF NOT EXISTS buckets (
-                user              TEXT NOT NULL,
-                name              TEXT NOT NULL,
-                created_at        TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S.000Z', 'now')),
-                versioning_state  TEXT NOT NULL DEFAULT 'disabled',
-                location          TEXT DEFAULT '',
+                user                TEXT NOT NULL,
+                name                TEXT NOT NULL,
+                created_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%S.000Z', 'now')),
+                versioning_state    TEXT NOT NULL DEFAULT 'disabled',
+                location            TEXT DEFAULT '',
+                object_lock_enabled INTEGER NOT NULL DEFAULT 0,
                 PRIMARY KEY (user, name)
             )",
             [],
         ).expect("Failed to create buckets table");
+
+        // Object lock — bucket-level default retention configuration
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS object_lock_config (
+                bucket TEXT PRIMARY KEY,
+                mode   TEXT NOT NULL,
+                days   INTEGER,
+                years  INTEGER
+            )",
+            [],
+        ).expect("Failed to create object_lock_config table");
+
+        // Object lock — per-version retention and legal hold
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS object_lock (
+                bucket            TEXT NOT NULL,
+                key               TEXT NOT NULL,
+                version_id        TEXT NOT NULL,
+                mode              TEXT,
+                retain_until_date TEXT,
+                legal_hold        TEXT NOT NULL DEFAULT 'OFF',
+                PRIMARY KEY (bucket, key, version_id)
+            )",
+            [],
+        ).expect("Failed to create object_lock table");
 
         // CORS configuration per bucket
         conn.execute(
@@ -1120,6 +1149,9 @@ pub struct MultipartUploadRow {
     pub final_etag: Option<String>,
     pub checksum_algorithm: String,
     pub checksum_type: String,
+    pub object_lock_mode: String,
+    pub object_lock_retain_until: String,
+    pub object_lock_legal_hold: String,
 }
 
 #[derive(Debug, Clone)]
@@ -1131,21 +1163,30 @@ pub struct MultipartPartRow {
     pub checksum_value: String,
 }
 
+pub struct ObjectLockRow {
+    pub mode: Option<String>,
+    pub retain_until_date: Option<String>,
+    pub legal_hold: String,
+}
+
 /// Multipart upload management
 impl SQLiteMetadataStore {
     pub fn create_multipart_upload(
         &self, upload_id: &str, user_id: &str, bucket: &str, key: &str,
         content_type: Option<&str>, metadata_json: &str, initiated_at: &str,
         checksum_algorithm: &str, checksum_type: &str,
+        object_lock_mode: &str, object_lock_retain_until: &str, object_lock_legal_hold: &str,
     ) -> Result<(), Error> {
         let conn = DB_CONN.lock().unwrap();
         conn.execute(
             "INSERT OR IGNORE INTO multipart_uploads
              (upload_id, user_id, bucket, key, content_type, metadata_json, initiated_at,
-              checksum_algorithm, checksum_type)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+              checksum_algorithm, checksum_type,
+              object_lock_mode, object_lock_retain_until, object_lock_legal_hold)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
             params![upload_id, user_id, bucket, key, content_type, metadata_json, initiated_at,
-                    checksum_algorithm, checksum_type],
+                    checksum_algorithm, checksum_type,
+                    object_lock_mode, object_lock_retain_until, object_lock_legal_hold],
         ).map_err(actix_web::error::ErrorInternalServerError)?;
         Ok(())
     }
@@ -1154,7 +1195,8 @@ impl SQLiteMetadataStore {
         let conn = DB_CONN.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT upload_id, user_id, bucket, key, content_type, metadata_json,
-                    initiated_at, status, final_etag, checksum_algorithm, checksum_type
+                    initiated_at, status, final_etag, checksum_algorithm, checksum_type,
+                    object_lock_mode, object_lock_retain_until, object_lock_legal_hold
              FROM multipart_uploads WHERE upload_id = ?1",
         ).map_err(actix_web::error::ErrorInternalServerError)?;
         let result = stmt.query_row(params![upload_id], |row| {
@@ -1170,6 +1212,9 @@ impl SQLiteMetadataStore {
                 final_etag: row.get(8)?,
                 checksum_algorithm: row.get::<_, Option<String>>(9)?.unwrap_or_default(),
                 checksum_type: row.get::<_, Option<String>>(10)?.unwrap_or_default(),
+                object_lock_mode: row.get::<_, Option<String>>(11)?.unwrap_or_default(),
+                object_lock_retain_until: row.get::<_, Option<String>>(12)?.unwrap_or_default(),
+                object_lock_legal_hold: row.get::<_, Option<String>>(13)?.unwrap_or_default(),
             })
         });
         match result {
@@ -1210,7 +1255,8 @@ impl SQLiteMetadataStore {
         let conn = DB_CONN.lock().unwrap();
         let mut stmt = conn.prepare(
             "SELECT upload_id, user_id, bucket, key, content_type, metadata_json,
-                    initiated_at, status, final_etag, checksum_algorithm, checksum_type
+                    initiated_at, status, final_etag, checksum_algorithm, checksum_type,
+                    object_lock_mode, object_lock_retain_until, object_lock_legal_hold
              FROM multipart_uploads
              WHERE bucket = ?1 AND status = 'in_progress'
              ORDER BY key, initiated_at",
@@ -1228,6 +1274,9 @@ impl SQLiteMetadataStore {
                 final_etag: row.get(8)?,
                 checksum_algorithm: row.get::<_, Option<String>>(9)?.unwrap_or_default(),
                 checksum_type: row.get::<_, Option<String>>(10)?.unwrap_or_default(),
+                object_lock_mode: row.get::<_, Option<String>>(11)?.unwrap_or_default(),
+                object_lock_retain_until: row.get::<_, Option<String>>(12)?.unwrap_or_default(),
+                object_lock_legal_hold: row.get::<_, Option<String>>(13)?.unwrap_or_default(),
             })
         }).map_err(actix_web::error::ErrorInternalServerError)?;
         let mut result = Vec::new();
@@ -1303,6 +1352,147 @@ impl SQLiteMetadataStore {
             params![manifest, user_id, bucket, key],
         ).map_err(actix_web::error::ErrorInternalServerError)?;
         Ok(())
+    }
+
+    // --- Object Lock ---
+
+    pub fn get_bucket_object_lock_enabled(&self, bucket: &str) -> Result<bool, Error> {
+        let conn = DB_CONN.lock().unwrap();
+        let result: rusqlite::Result<i64> = conn.query_row(
+            "SELECT object_lock_enabled FROM buckets WHERE name = ?1",
+            params![bucket],
+            |row| row.get(0),
+        );
+        match result {
+            Ok(v) => Ok(v != 0),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(false),
+            Err(e) => Err(actix_web::error::ErrorInternalServerError(e)),
+        }
+    }
+
+    pub fn set_bucket_object_lock_enabled(&self, bucket: &str, enabled: bool) -> Result<(), Error> {
+        let conn = DB_CONN.lock().unwrap();
+        conn.execute(
+            "UPDATE buckets SET object_lock_enabled = ?1 WHERE name = ?2",
+            params![if enabled { 1i64 } else { 0i64 }, bucket],
+        ).map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(())
+    }
+
+    pub fn create_bucket_with_lock(&self, user_id: &str, bucket: &str, lock_enabled: bool) -> Result<(), Error> {
+        let conn = DB_CONN.lock().unwrap();
+        let lock_val = if lock_enabled { 1i64 } else { 0i64 };
+        let versioning = if lock_enabled { "enabled" } else { "disabled" };
+        conn.execute(
+            "INSERT OR IGNORE INTO buckets (user, name, object_lock_enabled, versioning_state) VALUES (?1, ?2, ?3, ?4)",
+            params![user_id, bucket, lock_val, versioning],
+        ).map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(())
+    }
+
+    /// Returns None if no config set; Some((mode, days, years)) otherwise.
+    pub fn get_object_lock_config(&self, bucket: &str) -> Result<Option<(String, Option<i64>, Option<i64>)>, Error> {
+        let conn = DB_CONN.lock().unwrap();
+        let result = conn.query_row(
+            "SELECT mode, days, years FROM object_lock_config WHERE bucket = ?1",
+            params![bucket],
+            |row| Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<i64>>(1)?,
+                row.get::<_, Option<i64>>(2)?,
+            )),
+        );
+        match result {
+            Ok(r) => Ok(Some(r)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(actix_web::error::ErrorInternalServerError(e)),
+        }
+    }
+
+    pub fn put_object_lock_config(&self, bucket: &str, mode: &str, days: Option<i64>, years: Option<i64>) -> Result<(), Error> {
+        let conn = DB_CONN.lock().unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO object_lock_config (bucket, mode, days, years) VALUES (?1, ?2, ?3, ?4)",
+            params![bucket, mode, days, years],
+        ).map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(())
+    }
+
+    pub fn get_object_lock(&self, bucket: &str, key: &str, version_id: &str) -> Result<Option<ObjectLockRow>, Error> {
+        let conn = DB_CONN.lock().unwrap();
+        let result = conn.query_row(
+            "SELECT mode, retain_until_date, legal_hold FROM object_lock WHERE bucket = ?1 AND key = ?2 AND version_id = ?3",
+            params![bucket, key, version_id],
+            |row| Ok(ObjectLockRow {
+                mode: row.get(0)?,
+                retain_until_date: row.get(1)?,
+                legal_hold: row.get::<_, String>(2).unwrap_or_else(|_| "OFF".to_string()),
+            }),
+        );
+        match result {
+            Ok(r) => Ok(Some(r)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(actix_web::error::ErrorInternalServerError(e)),
+        }
+    }
+
+    pub fn put_object_lock(
+        &self, bucket: &str, key: &str, version_id: &str,
+        mode: Option<&str>, retain_until_date: Option<&str>, legal_hold: Option<&str>,
+    ) -> Result<(), Error> {
+        let conn = DB_CONN.lock().unwrap();
+        // INSERT uses COALESCE(?6, 'OFF') so a fresh row defaults legal_hold to 'OFF'.
+        // ON CONFLICT uses COALESCE(?6, legal_hold) so None (NULL) preserves the existing value.
+        conn.execute(
+            "INSERT INTO object_lock (bucket, key, version_id, mode, retain_until_date, legal_hold)
+             VALUES (?1, ?2, ?3, ?4, ?5, COALESCE(?6, 'OFF'))
+             ON CONFLICT(bucket, key, version_id) DO UPDATE SET
+               mode = COALESCE(?4, mode),
+               retain_until_date = COALESCE(?5, retain_until_date),
+               legal_hold = COALESCE(?6, legal_hold)",
+            params![bucket, key, version_id, mode, retain_until_date, legal_hold],
+        ).map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(())
+    }
+
+    pub fn set_object_legal_hold(&self, bucket: &str, key: &str, version_id: &str, status: &str) -> Result<(), Error> {
+        let conn = DB_CONN.lock().unwrap();
+        conn.execute(
+            "INSERT INTO object_lock (bucket, key, version_id, legal_hold)
+             VALUES (?1, ?2, ?3, ?4)
+             ON CONFLICT(bucket, key, version_id) DO UPDATE SET legal_hold = ?4",
+            params![bucket, key, version_id, status],
+        ).map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(())
+    }
+
+    /// Returns (blocked_by_retention, blocked_by_legal_hold).
+    /// bypass_governance: true allows overriding GOVERNANCE retention.
+    pub fn check_object_lock_protection(
+        &self, bucket: &str, key: &str, version_id: &str, bypass_governance: bool,
+    ) -> Result<(bool, bool), Error> {
+        let row = match self.get_object_lock(bucket, key, version_id)? {
+            Some(r) => r,
+            None => return Ok((false, false)),
+        };
+        let legal_hold_blocked = row.legal_hold == "ON";
+        let retention_blocked = match (&row.mode, &row.retain_until_date) {
+            (Some(mode), Some(until)) => {
+                let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
+                let still_locked = until.as_str() > now.as_str();
+                if still_locked {
+                    match mode.as_str() {
+                        "COMPLIANCE" => true,
+                        "GOVERNANCE" => !bypass_governance,
+                        _ => false,
+                    }
+                } else {
+                    false
+                }
+            }
+            _ => false,
+        };
+        Ok((retention_blocked, legal_hold_blocked))
     }
 }
 

--- a/server/src/s3/handlers/bucket.rs
+++ b/server/src/s3/handlers/bucket.rs
@@ -12,6 +12,7 @@ use super::common::*;
 use super::tagging::{s3_put_bucket_tagging_inner, s3_delete_bucket_tagging_inner};
 use super::versioning::s3_put_bucket_versioning_inner;
 use super::acl::{s3_put_acl_stub, validate_bucket_name};
+use super::object_lock::s3_put_bucket_object_lock_inner;
 
 // ---------------------------------------------------------------------------
 // ListBuckets  GET /s3  or  GET /s3/
@@ -107,13 +108,16 @@ pub async fn s3_create_bucket_handler(
     if qmap.contains_key("acl") {
         return s3_put_acl_stub(&req).await;
     }
-    if qmap.contains_key("tagging") || qmap.contains_key("versioning") {
+    if qmap.contains_key("tagging") || qmap.contains_key("versioning") || qmap.contains_key("object-lock") {
         let mut body: Vec<u8> = Vec::new();
         while let Some(chunk) = payload.next().await {
             body.extend_from_slice(&chunk.map_err(actix_web::error::ErrorInternalServerError)?);
         }
         if qmap.contains_key("tagging") {
             return s3_put_bucket_tagging_inner(&bucket, &body, &req).await;
+        }
+        if qmap.contains_key("object-lock") {
+            return s3_put_bucket_object_lock_inner(&bucket, &body, &req).await;
         }
         return s3_put_bucket_versioning_inner(&bucket, &body, &req).await;
     }
@@ -143,7 +147,12 @@ pub async fn s3_create_bucket_handler(
     if let Err(e) = validate_bucket_name(&bucket) { return Ok(e); }
 
     let db = MetadataService::new(&auth_result.user_id)?;
-    db.create_bucket(&bucket)?;
+    let lock_enabled = req.headers()
+        .get("x-amz-bucket-object-lock-enabled")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    db.create_bucket_with_lock(&bucket, lock_enabled)?;
 
     let location = extract_xml_tag(&body, "LocationConstraint")
         .map(|s| s.trim().to_string())

--- a/server/src/s3/handlers/common.rs
+++ b/server/src/s3/handlers/common.rs
@@ -278,3 +278,9 @@ pub(super) fn percent_decode(s: &str) -> String {
     }
     String::from_utf8_lossy(&out).into_owned()
 }
+
+pub(super) fn req_query_map(req: &HttpRequest) -> std::collections::HashMap<String, String> {
+    actix_web::web::Query::<std::collections::HashMap<String, String>>::from_query(req.query_string())
+        .map(|q| q.into_inner())
+        .unwrap_or_default()
+}

--- a/server/src/s3/handlers/listing.rs
+++ b/server/src/s3/handlers/listing.rs
@@ -14,6 +14,7 @@ use super::versioning::{s3_get_bucket_versioning_inner, s3_list_object_versions_
 use super::cors::{s3_get_bucket_cors_inner, s3_get_bucket_location_inner};
 use super::acl::s3_get_bucket_acl_stub;
 use super::multipart::s3_list_multipart_uploads_handler;
+use super::object_lock::s3_get_bucket_object_lock_inner;
 
 // ---------------------------------------------------------------------------
 // ListObjects  GET /s3/{bucket}
@@ -47,6 +48,9 @@ pub async fn s3_list_objects_handler(
     }
     if query.contains_key("versioning") {
         return s3_get_bucket_versioning_inner(&bucket, &req).await;
+    }
+    if query.contains_key("object-lock") {
+        return s3_get_bucket_object_lock_inner(&bucket, &req).await;
     }
     if query.contains_key("acl") {
         return s3_get_bucket_acl_stub(&bucket, &req).await;
@@ -367,10 +371,28 @@ pub async fn s3_delete_objects_handler(
     let mut deleted_xml = String::new();
     let mut errors_xml = String::new();
 
+    let bypass_governance = req.headers()
+        .get("x-amz-bypass-governance-retention")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
     for obj_req in &objects {
         let key = &obj_req.key;
 
         if let Some(ref vid) = obj_req.version_id {
+            // Check object lock before deleting
+            let (ret_blocked, hold_blocked) = db.check_object_lock_protection(&bucket, key, vid, bypass_governance)?;
+            if ret_blocked || hold_blocked {
+                errors_xml.push_str(&format!(
+                    "    <Error><Key>{k}</Key><VersionId>{v}</VersionId>\
+                     <Code>AccessDenied</Code>\
+                     <Message>Object is locked and cannot be deleted</Message></Error>\n",
+                    k = xml_escape(key), v = xml_escape(vid),
+                ));
+                continue;
+            }
+
             if let Ok(ver_meta) = db.get_object_version(&bucket, key, vid) {
                 let extents = ver_meta.to_offset_size_list();
                 if !extents.is_empty() {

--- a/server/src/s3/handlers/mod.rs
+++ b/server/src/s3/handlers/mod.rs
@@ -5,6 +5,7 @@ pub(super) mod cors;
 pub(super) mod tagging;
 pub(super) mod versioning;
 pub(super) mod acl;
+pub(super) mod object_lock;
 pub(super) mod bucket;
 pub(super) mod listing;
 pub(super) mod object;

--- a/server/src/s3/handlers/multipart.rs
+++ b/server/src/s3/handlers/multipart.rs
@@ -108,10 +108,18 @@ pub async fn s3_create_multipart_upload_handler(
         String::new()
     };
 
+    let mpu_lock_mode = req.headers().get("x-amz-object-lock-mode")
+        .and_then(|v| v.to_str().ok()).unwrap_or("").to_string();
+    let mpu_lock_until = req.headers().get("x-amz-object-lock-retain-until-date")
+        .and_then(|v| v.to_str().ok()).unwrap_or("").to_string();
+    let mpu_legal_hold = req.headers().get("x-amz-object-lock-legal-hold")
+        .and_then(|v| v.to_str().ok()).unwrap_or("").to_string();
+
     db.create_multipart_upload(
         &upload_id, &bucket, &key,
         content_type.as_deref(), &metadata_json, &initiated_at,
         &mpu_checksum_algo, &mpu_checksum_type,
+        &mpu_lock_mode, &mpu_lock_until, &mpu_legal_hold,
     )?;
 
     if let Some(tagging_str) = req.headers().get("x-amz-tagging").and_then(|v| v.to_str().ok()) {
@@ -557,18 +565,32 @@ pub async fn s3_complete_multipart_upload_handler(
         let _ = db.set_object_tags(&bucket, &key, &tags);
     }
 
+    // Apply object lock from multipart upload metadata
+    let lock_mode = &upload_row.object_lock_mode;
+    let lock_until = &upload_row.object_lock_retain_until;
+    let legal_hold = &upload_row.object_lock_legal_hold;
+    if !lock_mode.is_empty() || !legal_hold.is_empty() {
+        let effective_vid = mpu_vid.as_deref().unwrap_or("");
+        let hold_opt = if legal_hold.is_empty() { None } else { Some(legal_hold.as_str()) };
+        let _ = db.put_object_lock(
+            &bucket, &key, effective_vid,
+            if lock_mode.is_empty() { None } else { Some(lock_mode.as_str()) },
+            if lock_until.is_empty() { None } else { Some(lock_until.as_str()) },
+            hold_opt,
+        );
+    }
+
     info!("S3 CompleteMultipartUpload: bucket={} key={} parts={} etag={}", bucket, key, total_parts, multipart_etag);
     let mut resp = complete_multipart_xml_response(
         &bucket, &key, &multipart_etag,
         final_checksum_algo.as_deref(), final_checksum_value.as_deref(), final_checksum_type.as_deref(),
     );
-    if let Some(vid) = mpu_vid {
-        if vid != "null" {
-            resp.headers_mut().insert(
-                actix_web::http::header::HeaderName::from_static("x-amz-version-id"),
-                actix_web::http::header::HeaderValue::from_str(&vid).unwrap(),
-            );
-        }
+    let resp_vid = mpu_vid.as_deref().unwrap_or("");
+    if !resp_vid.is_empty() && resp_vid != "null" {
+        resp.headers_mut().insert(
+            actix_web::http::header::HeaderName::from_static("x-amz-version-id"),
+            actix_web::http::header::HeaderValue::from_str(resp_vid).unwrap(),
+        );
     }
     Ok(resp)
 }

--- a/server/src/s3/handlers/object.rs
+++ b/server/src/s3/handlers/object.rs
@@ -21,6 +21,7 @@ use super::versioning::{s3_get_object_version_handler, s3_delete_specific_versio
 use super::acl::{s3_put_acl_stub, s3_get_object_acl_stub, validate_object_key};
 use super::copy::s3_copy_object_handler;
 use super::multipart::{s3_upload_part_handler, s3_upload_part_copy_handler, s3_abort_multipart_upload_handler, s3_get_object_attributes_handler, s3_get_part_handler, s3_head_part_handler};
+use super::object_lock::{s3_put_object_retention_inner, s3_get_object_retention_inner, s3_put_object_legal_hold_inner, s3_get_object_legal_hold_inner, compute_retain_until};
 
 // ---------------------------------------------------------------------------
 // PutObject  PUT /s3/{bucket}/{key}
@@ -51,6 +52,17 @@ pub async fn s3_put_object_handler(
         }
         if query.contains_key("acl") {
             return s3_put_acl_stub(&req).await;
+        }
+        if query.contains_key("retention") || query.contains_key("legal-hold") {
+            let (bucket, key) = path.into_inner();
+            let mut body: Vec<u8> = Vec::new();
+            while let Some(chunk) = payload.next().await {
+                body.extend_from_slice(&chunk.map_err(actix_web::error::ErrorInternalServerError)?);
+            }
+            if query.contains_key("retention") {
+                return s3_put_object_retention_inner(&bucket, &key, &body, &req).await;
+            }
+            return s3_put_object_legal_hold_inner(&bucket, &key, &body, &req).await;
         }
     }
     if req.headers().contains_key("x-amz-copy-source") {
@@ -233,10 +245,46 @@ pub async fn s3_put_object_handler(
         db.set_object_tags(&bucket, &key, &tags)?;
     }
 
+    // Apply object lock — from per-object headers or bucket default retention
+    let obj_lock_mode = req.headers().get("x-amz-object-lock-mode")
+        .and_then(|v| v.to_str().ok()).map(|s| s.to_string());
+    let obj_lock_until = req.headers().get("x-amz-object-lock-retain-until-date")
+        .and_then(|v| v.to_str().ok()).map(|s| s.to_string());
+    let obj_legal_hold = req.headers().get("x-amz-object-lock-legal-hold")
+        .and_then(|v| v.to_str().ok()).map(|s| s.to_string());
+
+    let effective_vid = version_id.as_deref().unwrap_or("");
+    let lock_mode: Option<String>;
+    let lock_until: Option<String>;
+
+    if obj_lock_mode.is_some() && obj_lock_until.is_some() {
+        lock_mode = obj_lock_mode;
+        lock_until = obj_lock_until;
+    } else if let Ok(Some((def_mode, def_days, def_years))) = db.get_object_lock_config(&bucket) {
+        lock_mode = Some(def_mode);
+        lock_until = Some(compute_retain_until(def_days, def_years));
+    } else {
+        lock_mode = None;
+        lock_until = None;
+    }
+
+    if lock_mode.is_some() || obj_legal_hold.is_some() {
+        let _ = db.put_object_lock(
+            &bucket, &key, effective_vid,
+            lock_mode.as_deref(), lock_until.as_deref(),
+            obj_legal_hold.as_deref(),
+        );
+    }
+
     debug!("S3 PutObject OK: bucket={} key={} size={} etag={}", bucket, key, size, etag);
     let mut resp = HttpResponse::Ok();
     resp.insert_header(("ETag", etag));
-    if let Some(vid) = version_id { if vid != "null" { resp.insert_header(("x-amz-version-id", vid)); } }
+    let resp_vid = version_id.as_deref().unwrap_or("");
+    if !resp_vid.is_empty() && resp_vid != "null" {
+        resp.insert_header(("x-amz-version-id", resp_vid.to_string()));
+    }
+    if let Some(ref m) = lock_mode { resp.insert_header(("x-amz-object-lock-mode", m.clone())); }
+    if let Some(ref u) = lock_until { resp.insert_header(("x-amz-object-lock-retain-until-date", u.clone())); }
     // Echo checksum header in response
     if let Some((ref algo, ref value)) = checksum_result {
         let header_name = format!("x-amz-checksum-{}", algo.header_suffix());
@@ -262,6 +310,13 @@ pub async fn s3_get_object_handler(
     }
     if qmap.contains_key("tagging") {
         return s3_get_object_tagging_inner(&bucket, &key, &req).await;
+    }
+    // retention/legal-hold come before versionId — boto3 sends both params together
+    if qmap.contains_key("retention") {
+        return s3_get_object_retention_inner(&bucket, &key, &req).await;
+    }
+    if qmap.contains_key("legal-hold") {
+        return s3_get_object_legal_hold_inner(&bucket, &key, &req).await;
     }
     if let Some(vid) = qmap.get("versionId") {
         return s3_get_object_version_handler(&bucket, &key, vid, &req).await;
@@ -456,6 +511,14 @@ pub async fn s3_get_object_handler(
             }
         }
     }
+    // Return object lock headers if present
+    if let Some(ref vid) = meta.version_id {
+        if let Ok(Some(lock)) = db.get_object_lock(&bucket, &key, vid) {
+            if let Some(ref m) = lock.mode { resp.insert_header(("x-amz-object-lock-mode", m.clone())); }
+            if let Some(ref u) = lock.retain_until_date { resp.insert_header(("x-amz-object-lock-retain-until-date", u.clone())); }
+            if lock.legal_hold == "ON" { resp.insert_header(("x-amz-object-lock-legal-hold", "ON")); }
+        }
+    }
     Ok(resp.streaming(byte_stream))
 }
 
@@ -553,6 +616,15 @@ pub async fn s3_head_object_handler(
                     }
                 }
             }
+        }
+    }
+    // Return object lock headers if present
+    let vid_for_lock = meta.version_id.as_deref().unwrap_or("");
+    if !vid_for_lock.is_empty() {
+        if let Ok(Some(lock)) = db.get_object_lock(&bucket, &key, vid_for_lock) {
+            if let Some(ref m) = lock.mode { resp.insert_header(("x-amz-object-lock-mode", m.clone())); }
+            if let Some(ref u) = lock.retain_until_date { resp.insert_header(("x-amz-object-lock-retain-until-date", u.clone())); }
+            if lock.legal_hold == "ON" { resp.insert_header(("x-amz-object-lock-legal-hold", "ON")); }
         }
     }
     Ok(resp.message_body(HeadBody(object_size)).unwrap().map_into_boxed_body())

--- a/server/src/s3/handlers/object_lock.rs
+++ b/server/src/s3/handlers/object_lock.rs
@@ -1,0 +1,328 @@
+// Object Lock handlers — bucket config, per-object retention, legal hold.
+use actix_web::{HttpRequest, HttpResponse, Error, http::StatusCode};
+
+use crate::s3::auth::authenticate_s3_request;
+use crate::service::metadata_service::MetadataService;
+
+use super::common::*;
+
+// ---------------------------------------------------------------------------
+// Helper — compute retain-until-date from default retention config
+// ---------------------------------------------------------------------------
+
+pub fn compute_retain_until(days: Option<i64>, years: Option<i64>) -> String {
+    let now = chrono::Utc::now();
+    let dt = if let Some(d) = days {
+        now + chrono::Duration::days(d)
+    } else if let Some(y) = years {
+        now + chrono::Duration::days(y * 365)
+    } else {
+        now
+    };
+    dt.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string()
+}
+
+// ---------------------------------------------------------------------------
+// PUT /{bucket}?object-lock — set bucket-level object lock configuration
+// ---------------------------------------------------------------------------
+
+pub async fn s3_put_bucket_object_lock_inner(bucket: &str, body: &[u8], req: &HttpRequest) -> Result<HttpResponse, Error> {
+    let auth_result = authenticate_s3_request(req).await?;
+    let db = MetadataService::new(&auth_result.user_id)?;
+    if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
+
+    let xml = String::from_utf8_lossy(body);
+
+    // ObjectLockEnabled must be "Enabled"
+    let status = extract_xml_tag(&xml, "ObjectLockEnabled").unwrap_or_default();
+    if status != "Enabled" {
+        return Ok(s3_error(StatusCode::BAD_REQUEST, "MalformedXML",
+                           "ObjectLockEnabled must be 'Enabled'", bucket));
+    }
+
+    // Bucket must have object lock enabled (set at CreateBucket time) or versioning must be enabled
+    let lock_enabled = db.get_bucket_object_lock_enabled(bucket)?;
+    if !lock_enabled {
+        let vs = db.get_versioning_state(bucket)?;
+        if vs != "enabled" {
+            return Ok(s3_error(StatusCode::CONFLICT, "InvalidBucketState",
+                               "Object lock can only be enabled on a versioning-enabled bucket", bucket));
+        }
+        db.set_bucket_object_lock_enabled(bucket, true)?;
+    }
+
+    // Parse Rule/DefaultRetention
+    let mode = extract_xml_tag(&xml, "Mode").unwrap_or_default();
+    if !mode.is_empty() {
+        if mode != "COMPLIANCE" && mode != "GOVERNANCE" {
+            return Ok(s3_error(StatusCode::BAD_REQUEST, "MalformedXML",
+                               "Mode must be COMPLIANCE or GOVERNANCE", bucket));
+        }
+        let days_str  = extract_xml_tag(&xml, "Days").unwrap_or_default();
+        let years_str = extract_xml_tag(&xml, "Years").unwrap_or_default();
+
+        let has_days  = !days_str.is_empty();
+        let has_years = !years_str.is_empty();
+
+        if has_days && has_years {
+            return Ok(s3_error(StatusCode::BAD_REQUEST, "MalformedXML",
+                               "Cannot specify both Days and Years", bucket));
+        }
+
+        let days: Option<i64> = if has_days {
+            match days_str.parse::<i64>() {
+                Ok(d) if d > 0 => Some(d),
+                _ => return Ok(s3_error(StatusCode::BAD_REQUEST, "InvalidRetentionPeriod",
+                                        "Days must be a positive integer", bucket)),
+            }
+        } else { None };
+
+        let years: Option<i64> = if has_years {
+            match years_str.parse::<i64>() {
+                Ok(y) if y > 0 => Some(y),
+                _ => return Ok(s3_error(StatusCode::BAD_REQUEST, "InvalidRetentionPeriod",
+                                        "Years must be a positive integer", bucket)),
+            }
+        } else { None };
+
+        if days.is_none() && years.is_none() {
+            return Ok(s3_error(StatusCode::BAD_REQUEST, "MalformedXML",
+                               "DefaultRetention must specify Days or Years", bucket));
+        }
+
+        db.put_object_lock_config(bucket, &mode, days, years)?;
+    }
+
+    Ok(HttpResponse::Ok().insert_header(("Content-Length", "0")).body(""))
+}
+
+// ---------------------------------------------------------------------------
+// GET /{bucket}?object-lock — get bucket-level object lock configuration
+// ---------------------------------------------------------------------------
+
+pub async fn s3_get_bucket_object_lock_inner(bucket: &str, req: &HttpRequest) -> Result<HttpResponse, Error> {
+    let auth_result = authenticate_s3_request(req).await?;
+    let db = MetadataService::new(&auth_result.user_id)?;
+    if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
+
+    let lock_enabled = db.get_bucket_object_lock_enabled(bucket)?;
+    if !lock_enabled {
+        return Ok(s3_error(StatusCode::NOT_FOUND, "ObjectLockConfigurationNotFoundError",
+                           "Object Lock configuration does not exist for this bucket", bucket));
+    }
+
+    let rule_xml = match db.get_object_lock_config(bucket)? {
+        Some((mode, days, years)) => {
+            let period_xml = if let Some(d) = days {
+                format!("<Days>{}</Days>", d)
+            } else if let Some(y) = years {
+                format!("<Years>{}</Years>", y)
+            } else {
+                String::new()
+            };
+            format!(
+                "<Rule><DefaultRetention><Mode>{mode}</Mode>{period}</DefaultRetention></Rule>",
+                mode = xml_escape(&mode), period = period_xml,
+            )
+        }
+        None => String::new(),
+    };
+
+    let xml = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <ObjectLockConfiguration xmlns=\"{s3}\">\
+         <ObjectLockEnabled>Enabled</ObjectLockEnabled>\
+         {rule}\
+         </ObjectLockConfiguration>",
+        s3 = S3_XMLNS, rule = rule_xml,
+    );
+    Ok(HttpResponse::Ok().content_type("application/xml").body(xml))
+}
+
+// ---------------------------------------------------------------------------
+// PUT /{bucket}/{key}?retention — set per-object retention
+// ---------------------------------------------------------------------------
+
+pub async fn s3_put_object_retention_inner(bucket: &str, key: &str, body: &[u8], req: &HttpRequest) -> Result<HttpResponse, Error> {
+    let auth_result = authenticate_s3_request(req).await?;
+    let db = MetadataService::new(&auth_result.user_id)?;
+    if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
+
+    let lock_enabled = db.get_bucket_object_lock_enabled(bucket)?;
+    if !lock_enabled {
+        return Ok(s3_error(StatusCode::BAD_REQUEST, "InvalidRequest",
+                           "Bucket does not have object lock enabled", &format!("/{}/{}", bucket, key)));
+    }
+
+    let xml = String::from_utf8_lossy(body);
+    let mode = extract_xml_tag(&xml, "Mode").unwrap_or_default();
+    if mode != "COMPLIANCE" && mode != "GOVERNANCE" {
+        return Ok(s3_error(StatusCode::BAD_REQUEST, "MalformedXML",
+                           "Mode must be COMPLIANCE or GOVERNANCE", &format!("/{}/{}", bucket, key)));
+    }
+
+    let retain_until = extract_xml_tag(&xml, "RetainUntilDate").unwrap_or_default();
+    if retain_until.is_empty() {
+        return Ok(s3_error(StatusCode::BAD_REQUEST, "MalformedXML",
+                           "RetainUntilDate is required", &format!("/{}/{}", bucket, key)));
+    }
+
+    let qmap = req_query_map(req);
+    let version_id = qmap.get("versionId").cloned().unwrap_or_default();
+
+    let bypass_governance = req.headers()
+        .get("x-amz-bypass-governance-retention")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    let vid = if version_id.is_empty() {
+        db.get_object_full(bucket, key)
+            .ok()
+            .and_then(|m| m.version_id)
+            .unwrap_or_default()
+    } else {
+        version_id
+    };
+
+    // Enforce retention protection: check existing lock before overwriting
+    if let Some(existing) = db.get_object_lock(bucket, key, &vid)? {
+        if let (Some(ref ex_mode), Some(ref ex_until)) = (&existing.mode, &existing.retain_until_date) {
+            let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();
+            if ex_until.as_str() > now.as_str() {
+                let shortening = retain_until.as_str() < ex_until.as_str();
+                let mode_changed = mode.as_str() != ex_mode.as_str();
+                let blocked = match ex_mode.as_str() {
+                    "COMPLIANCE" => shortening || mode_changed,
+                    "GOVERNANCE" => !bypass_governance && (shortening || mode_changed),
+                    _ => false,
+                };
+                if blocked {
+                    return Ok(s3_error(StatusCode::FORBIDDEN, "AccessDenied",
+                                       "Object is locked and the retention cannot be changed as requested",
+                                       &format!("/{}/{}", bucket, key)));
+                }
+            }
+        }
+        if existing.legal_hold == "ON" && !bypass_governance {
+            // Legal hold alone does NOT block retention changes
+        }
+    }
+
+    db.put_object_lock(bucket, key, &vid, Some(&mode), Some(&retain_until), None)?;
+    Ok(HttpResponse::Ok().insert_header(("Content-Length", "0")).body(""))
+}
+
+// ---------------------------------------------------------------------------
+// GET /{bucket}/{key}?retention — get per-object retention
+// ---------------------------------------------------------------------------
+
+pub async fn s3_get_object_retention_inner(bucket: &str, key: &str, req: &HttpRequest) -> Result<HttpResponse, Error> {
+    let auth_result = authenticate_s3_request(req).await?;
+    let db = MetadataService::new(&auth_result.user_id)?;
+    if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
+
+    let lock_enabled = db.get_bucket_object_lock_enabled(bucket)?;
+    if !lock_enabled {
+        return Ok(s3_error(StatusCode::BAD_REQUEST, "InvalidRequest",
+                           "Bucket does not have object lock enabled", &format!("/{}/{}", bucket, key)));
+    }
+
+    let qmap = req_query_map(req);
+    let version_id = qmap.get("versionId").cloned().unwrap_or_else(|| {
+        db.get_object_full(bucket, key)
+            .ok()
+            .and_then(|m| m.version_id)
+            .unwrap_or_default()
+    });
+
+    let lock = match db.get_object_lock(bucket, key, &version_id)? {
+        Some(r) => r,
+        None => return Ok(s3_error(StatusCode::NOT_FOUND, "NoSuchObjectLockConfiguration",
+                                   "Object does not have a retention configuration", &format!("/{}/{}", bucket, key))),
+    };
+
+    let (mode, until) = match (lock.mode, lock.retain_until_date) {
+        (Some(m), Some(u)) => (m, u),
+        _ => return Ok(s3_error(StatusCode::NOT_FOUND, "NoSuchObjectLockConfiguration",
+                                "Object does not have a retention configuration", &format!("/{}/{}", bucket, key))),
+    };
+
+    let xml = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <Retention xmlns=\"{s3}\">\
+         <Mode>{mode}</Mode>\
+         <RetainUntilDate>{until}</RetainUntilDate>\
+         </Retention>",
+        s3 = S3_XMLNS, mode = xml_escape(&mode), until = xml_escape(&until),
+    );
+    Ok(HttpResponse::Ok().content_type("application/xml").body(xml))
+}
+
+// ---------------------------------------------------------------------------
+// PUT /{bucket}/{key}?legal-hold — set legal hold
+// ---------------------------------------------------------------------------
+
+pub async fn s3_put_object_legal_hold_inner(bucket: &str, key: &str, body: &[u8], req: &HttpRequest) -> Result<HttpResponse, Error> {
+    let auth_result = authenticate_s3_request(req).await?;
+    let db = MetadataService::new(&auth_result.user_id)?;
+    if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
+
+    let lock_enabled = db.get_bucket_object_lock_enabled(bucket)?;
+    if !lock_enabled {
+        return Ok(s3_error(StatusCode::BAD_REQUEST, "InvalidRequest",
+                           "Bucket does not have object lock enabled", &format!("/{}/{}", bucket, key)));
+    }
+
+    let xml = String::from_utf8_lossy(body);
+    let status = extract_xml_tag(&xml, "Status").unwrap_or_default();
+    if status != "ON" && status != "OFF" {
+        return Ok(s3_error(StatusCode::BAD_REQUEST, "MalformedXML",
+                           "Legal hold Status must be ON or OFF", &format!("/{}/{}", bucket, key)));
+    }
+
+    let qmap = req_query_map(req);
+    let vid = qmap.get("versionId").cloned().unwrap_or_else(|| {
+        db.get_object_full(bucket, key)
+            .ok()
+            .and_then(|m| m.version_id)
+            .unwrap_or_default()
+    });
+
+    db.set_object_legal_hold(bucket, key, &vid, &status)?;
+    Ok(HttpResponse::Ok().insert_header(("Content-Length", "0")).body(""))
+}
+
+// ---------------------------------------------------------------------------
+// GET /{bucket}/{key}?legal-hold — get legal hold
+// ---------------------------------------------------------------------------
+
+pub async fn s3_get_object_legal_hold_inner(bucket: &str, key: &str, req: &HttpRequest) -> Result<HttpResponse, Error> {
+    let auth_result = authenticate_s3_request(req).await?;
+    let db = MetadataService::new(&auth_result.user_id)?;
+    if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
+
+    let lock_enabled = db.get_bucket_object_lock_enabled(bucket)?;
+    if !lock_enabled {
+        return Ok(s3_error(StatusCode::BAD_REQUEST, "InvalidRequest",
+                           "Bucket does not have object lock enabled", &format!("/{}/{}", bucket, key)));
+    }
+
+    let qmap = req_query_map(req);
+    let version_id = qmap.get("versionId").cloned().unwrap_or_else(|| {
+        db.get_object_full(bucket, key)
+            .ok()
+            .and_then(|m| m.version_id)
+            .unwrap_or_default()
+    });
+
+    let lock = db.get_object_lock(bucket, key, &version_id)?;
+    let status = lock.as_ref().map(|r| r.legal_hold.as_str()).unwrap_or("OFF");
+
+    let xml = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <LegalHold xmlns=\"{s3}\"><Status>{status}</Status></LegalHold>",
+        s3 = S3_XMLNS, status = xml_escape(status),
+    );
+    Ok(HttpResponse::Ok().content_type("application/xml").body(xml))
+}

--- a/server/src/s3/handlers/versioning.rs
+++ b/server/src/s3/handlers/versioning.rs
@@ -20,6 +20,10 @@ pub(super) async fn s3_put_bucket_versioning_inner(bucket: &str, body: &[u8], re
         _ => return Ok(s3_error(StatusCode::BAD_REQUEST, "MalformedXML",
                                 "Invalid versioning configuration", bucket)),
     };
+    if state == "suspended" && db.get_bucket_object_lock_enabled(bucket)? {
+        return Ok(s3_error(StatusCode::CONFLICT, "InvalidBucketState",
+                           "Cannot suspend versioning on a bucket with object lock enabled", bucket));
+    }
     db.set_versioning_state(bucket, state)?;
     Ok(HttpResponse::Ok().insert_header(("Content-Length", "0")).body(""))
 }
@@ -53,6 +57,18 @@ pub(super) async fn s3_delete_specific_version_handler(bucket: &str, key: &str, 
     let auth_result = authenticate_s3_request(req).await?;
     let db = MetadataService::new(&auth_result.user_id)?;
     if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
+
+    let bypass_governance = req.headers()
+        .get("x-amz-bypass-governance-retention")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    let (ret_blocked, hold_blocked) = db.check_object_lock_protection(bucket, key, version_id, bypass_governance)?;
+    if ret_blocked || hold_blocked {
+        return Ok(s3_error(StatusCode::FORBIDDEN, "AccessDenied",
+                           "Object is locked and cannot be deleted", &format!("/{}/{}", bucket, key)));
+    }
 
     if let Ok(ver_meta) = db.get_object_version(bucket, key, version_id) {
         let extents = ver_meta.to_offset_size_list();
@@ -126,7 +142,14 @@ pub(super) async fn s3_get_object_version_handler(bucket: &str, key: &str, versi
     resp.insert_header(("ETag", etag));
     resp.insert_header(("Content-Length", total_size.to_string()));
     if !last_modified.is_empty() { resp.insert_header(("Last-Modified", last_modified)); }
-    if let Some(vid) = &meta.version_id { resp.insert_header(("x-amz-version-id", vid.clone())); }
+    if let Some(vid) = &meta.version_id {
+        resp.insert_header(("x-amz-version-id", vid.clone()));
+        if let Ok(Some(lock)) = db.get_object_lock(bucket, key, vid) {
+            if let Some(ref m) = lock.mode { resp.insert_header(("x-amz-object-lock-mode", m.clone())); }
+            if let Some(ref u) = lock.retain_until_date { resp.insert_header(("x-amz-object-lock-retain-until-date", u.clone())); }
+            if lock.legal_hold == "ON" { resp.insert_header(("x-amz-object-lock-legal-hold", "ON")); }
+        }
+    }
     for (k, v) in &meta.user_metadata {
         resp.insert_header((format!("x-amz-meta-{}", k), metadata_value_header(v)));
     }

--- a/server/src/service/metadata_service.rs
+++ b/server/src/service/metadata_service.rs
@@ -268,11 +268,13 @@ impl MetadataService {
         &self, upload_id: &str, bucket: &str, key: &str,
         content_type: Option<&str>, metadata_json: &str, initiated_at: &str,
         checksum_algorithm: &str, checksum_type: &str,
+        object_lock_mode: &str, object_lock_retain_until: &str, object_lock_legal_hold: &str,
     ) -> Result<(), Error> {
         use crate::metadata::sqlite_store::SQLiteMetadataStore;
         SQLiteMetadataStore::new().create_multipart_upload(
             upload_id, &self.user, bucket, key, content_type, metadata_json, initiated_at,
             checksum_algorithm, checksum_type,
+            object_lock_mode, object_lock_retain_until, object_lock_legal_hold,
         )
     }
 
@@ -333,6 +335,60 @@ impl MetadataService {
     pub fn set_parts_manifest(&self, bucket: &str, key: &str, manifest: &str) -> Result<(), Error> {
         use crate::metadata::sqlite_store::SQLiteMetadataStore;
         SQLiteMetadataStore::new().set_parts_manifest(&self.user, bucket, key, manifest)
+    }
+
+    // --- Object Lock ---
+
+    pub fn get_bucket_object_lock_enabled(&self, bucket: &str) -> Result<bool, Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().get_bucket_object_lock_enabled(bucket)
+    }
+
+    pub fn set_bucket_object_lock_enabled(&self, bucket: &str, enabled: bool) -> Result<(), Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().set_bucket_object_lock_enabled(bucket, enabled)
+    }
+
+    pub fn create_bucket_with_lock(&self, bucket: &str, lock_enabled: bool) -> Result<(), Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().create_bucket_with_lock(&self.user, bucket, lock_enabled)
+    }
+
+    pub fn get_object_lock_config(&self, bucket: &str) -> Result<Option<(String, Option<i64>, Option<i64>)>, Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().get_object_lock_config(bucket)
+    }
+
+    pub fn put_object_lock_config(&self, bucket: &str, mode: &str, days: Option<i64>, years: Option<i64>) -> Result<(), Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().put_object_lock_config(bucket, mode, days, years)
+    }
+
+    pub fn get_object_lock(&self, bucket: &str, key: &str, version_id: &str)
+        -> Result<Option<crate::metadata::sqlite_store::ObjectLockRow>, Error>
+    {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().get_object_lock(bucket, key, version_id)
+    }
+
+    pub fn put_object_lock(
+        &self, bucket: &str, key: &str, version_id: &str,
+        mode: Option<&str>, retain_until_date: Option<&str>, legal_hold: Option<&str>,
+    ) -> Result<(), Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().put_object_lock(bucket, key, version_id, mode, retain_until_date, legal_hold)
+    }
+
+    pub fn set_object_legal_hold(&self, bucket: &str, key: &str, version_id: &str, status: &str) -> Result<(), Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().set_object_legal_hold(bucket, key, version_id, status)
+    }
+
+    pub fn check_object_lock_protection(
+        &self, bucket: &str, key: &str, version_id: &str, bypass_governance: bool,
+    ) -> Result<(bool, bool), Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().check_object_lock_protection(bucket, key, version_id, bypass_governance)
     }
 }
 


### PR DESCRIPTION
Implements S3 Object Lock (WORM) with COMPLIANCE and GOVERNANCE retention modes, legal hold, per-object and bucket-default retention policies, and full multipart upload lock propagation. All 39 test_object_lock_* Ceph tests now pass.

Key additions:
- object_lock and object_lock_config SQLite tables; object_lock_enabled column on buckets; lock columns on multipart_uploads
- object_lock.rs: handlers for PUT/GET ?object-lock (bucket config), ?retention, ?legal-hold
- COMPLIANCE: immutable retain_until_date and mode, no bypass allowed
- GOVERNANCE: shortening date or mode change requires x-amz-bypass-governance-retention: true header
- check_object_lock_protection enforced on every versioned delete (single and multi-delete)
- PutObject applies per-object lock headers or falls back to bucket default retention config
- CompleteMultipartUpload propagates lock from create_multipart_upload
- HEAD/GET return x-amz-object-lock-mode, -retain-until-date, -legal-hold
- Fix: boto3 legal hold header is x-amz-object-lock-legal-hold (no -status suffix)
- Fix: GET routing dispatches ?retention/?legal-hold before ?versionId
- Suspend versioning on object-lock bucket returns 409 InvalidBucketState

Running total: 433 / 808 Ceph tests passing