### PR TITLE
feat(batch-10): S3 ACL

### DIFF
--- a/docs/TEST-COVERAGE.md
+++ b/docs/TEST-COVERAGE.md
@@ -701,7 +701,7 @@ test_get_checksum_object_attributes
 ## feat/batch-14-object-lock — Batch 14: S3 Object Lock (WORM)
 
 **Branch:** `feat/batch-14-object-lock`
-**RFC Batch:** Batch 14 (RFC 2.6 — Object Lock)
+**RFC Batch:** Batch 14 (RFC 2.22 — Object Lock)
 **Newly passing:** 39
 
 Key changes:
@@ -818,7 +818,102 @@ test_cors_presigned_put_object
 
 ### Intentionally deferred (2 tests)
 
-- `test_cors_origin_response` — requires public-read ACL (unauthenticated GET → 403 without Batch 10)
+- `test_cors_origin_response` — anonymous GET now correctly returns 200 (Batch 10 public-read ACL), but the CORS `Access-Control-Allow-Origin` header is only applied on `OPTIONS` preflight, not echoed onto the actual `GET`/`PUT` response — separate CORS gap, not an ACL issue
 - `test_cors_origin_wildcard` — same reason
 
 **Running total: 242 / 808**
+
+---
+
+## feat/batch-10-acl — Batch 10: S3 ACL (canned ACLs, header/XML grants, Block Public Access)
+
+**Branch:** `feat/batch-10-acl`
+**RFC Batch:** Batch 10 (RFC 2.10 — ACL)
+**Newly passing:** 49
+
+Key changes:
+- `bucket_acl` / `object_acl` / `public_access_block` SQLite tables: JSON grant lists keyed by owner; no row = default-private, synthesized at read time
+- `acl.rs` rewritten: canned ACL expansion (`private`/`public-read`/`public-read-write`/`authenticated-read`/`bucket-owner-*`), `x-amz-grant-*` header parsing, arbitrary `AccessControlPolicy` XML body parsing/serialization, Block Public Access CRUD + enforcement, `?policyStatus`
+- `auth.rs`: genuine anonymous request path (`authenticate_s3_request_allow_anonymous`) alongside the existing strict `authenticate_s3_request`, so ~35 unrelated call sites keep their original behavior; `WARPDRIVE_ADMIN_DISPLAY_NAME` env var (default `"Warpdrive Admin"`) plus `owner_display_name`/`is_anonymous` on `S3AuthResult`
+- Anonymous GET/HEAD/PUT/ListObjects/ListBuckets gate on stored ACL, checked *before* bucket/key existence so a nonexistent resource never leaks via 404 vs 403 (matches real S3); anonymous `ListBuckets` returns 200 with an empty list rather than an error
+- `x-amz-expected-bucket-owner` now actually validated (previously accepted but ignored)
+- Bad/unrecognized SigV4 credentials now return 403 `AccessDenied` instead of 401 (matches Ceph's `test_list_buckets_invalid_auth`/`test_list_buckets_bad_auth`)
+- Fixed a pre-existing bug where `<Owner><DisplayName>` echoed the owner ID instead of the real display name, across `bucket.rs` (ListBuckets), `listing.rs` (ListObjects), `versioning.rs` (ListObjectVersions), and `multipart.rs` (ListMultipartUploads `<Initiator>`/`<Owner>`)
+- Bonus fix: `validate_bucket_name` (`acl.rs`) now rejects IPv4-shaped bucket names and adjacent `.-`/`-.` sequences, matching real S3's legacy DNS-compliant naming rules — found because a bucket literally named `192.168.5.123` was slipping through and polluting `test_list_buckets_paginated` in full-suite runs
+- Bonus fix: GetObject no longer echoes the whole-object `x-amz-checksum-*` header on ranged (`Content-Range`) responses — botocore validates that header against the response body by default, so echoing a whole-object checksum on a partial body broke `test_ranged_request_*`
+
+### Verified Passing (49)
+
+```
+test_bucket_acl_canned
+test_bucket_acl_canned_authenticatedread
+test_bucket_acl_canned_during_create
+test_bucket_acl_canned_publicreadwrite
+test_bucket_acl_default
+test_bucket_acl_revoke_all
+test_bucket_put_bad_canned_acl
+test_put_bucket_acl_grant_group_read
+test_object_acl
+test_object_acl_canned
+test_object_acl_canned_authenticatedread
+test_object_acl_canned_during_create
+test_object_acl_canned_publicreadwrite
+test_object_acl_default
+test_object_acl_full_control_verify_attributes
+test_object_acl_read
+test_object_acl_readacp
+test_object_acl_write
+test_object_acl_writeacp
+test_object_copy_canned_acl
+test_object_copy_not_owned_object_bucket
+test_object_put_acl_mtime
+test_object_anon_put_write_access
+test_object_raw_get
+test_object_raw_get_bucket_acl
+test_object_raw_get_bucket_gone
+test_object_raw_get_object_gone
+test_block_public_put_bucket_acls
+test_block_public_policy_with_principal
+test_put_get_delete_public_block
+test_put_public_block
+test_list_buckets_anonymous
+test_list_buckets_bad_auth
+test_list_buckets_invalid_auth
+test_bucket_list_objects_anonymous
+test_bucket_listv2_objects_anonymous
+test_bucket_list_return_data
+test_bucket_list_special_prefix
+test_multipart_copy_small
+test_multipart_copy_special_names
+test_multipart_copy_multiple_sizes
+test_multipart_copy_without_range
+test_cors_presigned_get_object_tenant
+test_cors_presigned_put_object_tenant
+test_cors_presigned_put_object_tenant_with_acl
+test_cors_presigned_put_object_with_acl
+test_bucket_create_naming_bad_ip
+test_bucket_create_naming_dns_dash_dot
+test_bucket_create_naming_dns_dot_dash
+```
+
+Also fixed as a regression-during-development (already counted in the 433 baseline, not in the 49 above, but re-verified passing after the checksum-on-range fix): `test_ranged_request_response_code`, `test_ranged_big_request_response_code`, `test_ranged_request_skip_leading_bytes_response_code`, `test_ranged_request_return_trailing_bytes_response_code`, `test_list_buckets_paginated`.
+
+### Intentionally deferred
+
+Same-adminkey limitation — `s3-tests.conf`'s `[s3 main]`/`[s3 alt]` share one access key, so `alt_client` always authenticates as the same owner and can never be genuinely denied:
+- `test_access_bucket_private_object_private`, `test_access_bucket_private_objectv2_private`, `test_access_bucket_private_object_publicread`, `test_access_bucket_private_objectv2_publicread`, `test_access_bucket_private_object_publicreadwrite`, `test_access_bucket_private_objectv2_publicreadwrite`, `test_access_bucket_publicread_object_private`, `test_access_bucket_publicread_object_publicread`, `test_access_bucket_publicread_object_publicreadwrite`, `test_access_bucket_publicreadwrite_object_private`, `test_access_bucket_publicreadwrite_object_publicread`, `test_access_bucket_publicreadwrite_object_publicreadwrite`
+- `test_bucket_acl_grant_userid_fullcontrol`, `test_bucket_acl_grant_userid_read`, `test_bucket_acl_grant_userid_readacp`, `test_bucket_acl_grant_userid_write`, `test_bucket_acl_grant_userid_writeacp`
+- `test_ignore_public_acls`
+
+No user directory to resolve grantees against:
+- `test_bucket_acl_grant_nonexist_user` — needs grantee-existence validation
+- `test_bucket_acl_grant_email`, `test_bucket_acl_grant_email_not_exist` — needs an email→canonical-ID directory
+- `test_object_header_acl_grants`, `test_bucket_header_acl_grants` — same shared-adminkey limitation as above (assert on a specific non-owner grantee)
+
+Needs object owner != bucket owner (two real identities):
+- `test_object_acl_canned_bucketownerread`, `test_object_acl_canned_bucketownerfullcontrol`
+
+Needs `PutBucketPolicy` (RFC 2.13, separate batch):
+- `test_get_public_block_deny_bucket_policy`, `test_block_public_policy`, `test_block_public_restrict_public_buckets`, `test_get_publicpolicy_acl_bucket_policy_status`, `test_get_nonpublicpolicy_acl_bucket_policy_status`
+
+**Running total: 482 / 808**

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -76,7 +76,10 @@ async fn main() -> std::io::Result<()> {
             .route("/{bucket}/",         web::method(actix_web::http::Method::OPTIONS).to(s3_cors_not_configured_handler))
             .route("/{bucket}/{key:.*}", web::method(actix_web::http::Method::OPTIONS).to(s3_cors_not_configured_handler))
     })
-    .bind(("0.0.0.0", 9710))?
+    .bind((
+        "0.0.0.0",
+        std::env::var("WARPDRIVE_PORT").ok().and_then(|p| p.parse().ok()).unwrap_or(9710u16),
+    ))?
     .run()
     .await
 }

--- a/server/src/metadata/sqlite_store.rs
+++ b/server/src/metadata/sqlite_store.rs
@@ -218,6 +218,42 @@ lazy_static! {
             [],
         ).expect("Failed to create bucket_tags table");
 
+        // Bucket ACL — canned/header/XML-resolved grant list, JSON-serialized.
+        // No row = default private (owner-only FULL_CONTROL), synthesized at read time.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS bucket_acl (
+                bucket      TEXT PRIMARY KEY,
+                owner_id    TEXT NOT NULL,
+                grants_json TEXT NOT NULL
+            )",
+            [],
+        ).expect("Failed to create bucket_acl table");
+
+        // Object ACL — same shape as bucket_acl, keyed per version.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS object_acl (
+                bucket      TEXT NOT NULL,
+                key         TEXT NOT NULL,
+                version_id  TEXT NOT NULL DEFAULT '',
+                owner_id    TEXT NOT NULL,
+                grants_json TEXT NOT NULL,
+                PRIMARY KEY (bucket, key, version_id)
+            )",
+            [],
+        ).expect("Failed to create object_acl table");
+
+        // Block Public Access — four flags per bucket
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS public_access_block (
+                bucket                  TEXT PRIMARY KEY,
+                block_public_acls       INTEGER NOT NULL DEFAULT 0,
+                ignore_public_acls      INTEGER NOT NULL DEFAULT 0,
+                block_public_policy     INTEGER NOT NULL DEFAULT 0,
+                restrict_public_buckets INTEGER NOT NULL DEFAULT 0
+            )",
+            [],
+        ).expect("Failed to create public_access_block table");
+
         Arc::new(Mutex::new(conn))
     };
 }
@@ -740,6 +776,91 @@ impl SQLiteMetadataStore {
             Err(rusqlite::Error::QueryReturnedNoRows) => Ok(String::new()),
             Err(e) => Err(actix_web::error::ErrorInternalServerError(e)),
         }
+    }
+}
+
+/// ACL: bucket/object grant storage + Block Public Access flags
+impl SQLiteMetadataStore {
+    pub fn set_bucket_acl(&self, bucket: &str, owner_id: &str, grants_json: &str) -> Result<(), Error> {
+        let conn = DB_CONN.lock().unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO bucket_acl (bucket, owner_id, grants_json) VALUES (?1, ?2, ?3)",
+            params![bucket, owner_id, grants_json],
+        ).map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(())
+    }
+
+    pub fn get_bucket_acl(&self, bucket: &str) -> Result<Option<(String, String)>, Error> {
+        let conn = DB_CONN.lock().unwrap();
+        let mut stmt = conn.prepare("SELECT owner_id, grants_json FROM bucket_acl WHERE bucket = ?1")
+            .map_err(actix_web::error::ErrorInternalServerError)?;
+        let result = stmt.query_row(params![bucket], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        });
+        match result {
+            Ok(row) => Ok(Some(row)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(actix_web::error::ErrorInternalServerError(e)),
+        }
+    }
+
+    pub fn set_object_acl(&self, bucket: &str, key: &str, version_id: &str, owner_id: &str, grants_json: &str) -> Result<(), Error> {
+        let conn = DB_CONN.lock().unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO object_acl (bucket, key, version_id, owner_id, grants_json) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![bucket, key, version_id, owner_id, grants_json],
+        ).map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(())
+    }
+
+    pub fn get_object_acl(&self, bucket: &str, key: &str, version_id: &str) -> Result<Option<(String, String)>, Error> {
+        let conn = DB_CONN.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT owner_id, grants_json FROM object_acl WHERE bucket = ?1 AND key = ?2 AND version_id = ?3",
+        ).map_err(actix_web::error::ErrorInternalServerError)?;
+        let result = stmt.query_row(params![bucket, key, version_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        });
+        match result {
+            Ok(row) => Ok(Some(row)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(actix_web::error::ErrorInternalServerError(e)),
+        }
+    }
+
+    pub fn set_public_access_block(&self, bucket: &str, block_public_acls: bool, ignore_public_acls: bool, block_public_policy: bool, restrict_public_buckets: bool) -> Result<(), Error> {
+        let conn = DB_CONN.lock().unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO public_access_block
+                (bucket, block_public_acls, ignore_public_acls, block_public_policy, restrict_public_buckets)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![bucket, block_public_acls, ignore_public_acls, block_public_policy, restrict_public_buckets],
+        ).map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(())
+    }
+
+    /// Returns (block_public_acls, ignore_public_acls, block_public_policy, restrict_public_buckets).
+    pub fn get_public_access_block(&self, bucket: &str) -> Result<Option<(bool, bool, bool, bool)>, Error> {
+        let conn = DB_CONN.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT block_public_acls, ignore_public_acls, block_public_policy, restrict_public_buckets
+             FROM public_access_block WHERE bucket = ?1",
+        ).map_err(actix_web::error::ErrorInternalServerError)?;
+        let result = stmt.query_row(params![bucket], |row| {
+            Ok((row.get::<_, bool>(0)?, row.get::<_, bool>(1)?, row.get::<_, bool>(2)?, row.get::<_, bool>(3)?))
+        });
+        match result {
+            Ok(row) => Ok(Some(row)),
+            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+            Err(e) => Err(actix_web::error::ErrorInternalServerError(e)),
+        }
+    }
+
+    pub fn delete_public_access_block(&self, bucket: &str) -> Result<(), Error> {
+        let conn = DB_CONN.lock().unwrap();
+        conn.execute("DELETE FROM public_access_block WHERE bucket = ?1", params![bucket])
+            .map_err(actix_web::error::ErrorInternalServerError)?;
+        Ok(())
     }
 }
 

--- a/server/src/s3/auth.rs
+++ b/server/src/s3/auth.rs
@@ -39,16 +39,37 @@ struct S3CredentialsResponse {
     registered_buckets: Vec<String>,
 }
 
+/// The single static admin identity's canonical user ID. Every bucket/object in
+/// admin-only mode is owned by this ID — resource-owner lookups use this constant
+/// rather than a literal so the one place that assumes "single owner" is easy to
+/// find and replace once Vitality Console (UAM) can resolve real per-bucket owners.
+pub const ADMIN_USER_ID: &str = "admin";
+
 /// S3 Authentication result
 #[derive(Debug)]
 pub struct S3AuthResult {
     pub access_key: String,
     pub user_id: String,
+    /// Owner display name for ACL/Owner XML elements (e.g. "Warpdrive Admin").
+    /// Empty for anonymous requests.
+    pub owner_display_name: String,
     pub bucket: String,
     /// Snapshot of Console-registered buckets for this key (from credential cache at refresh time).
     pub allowed_buckets: Vec<String>,
     /// True for the hardcoded admin user — skips bucket membership checks so any bucket is reachable.
     pub allow_all_buckets: bool,
+    /// True when the request had no Authorization header and no presigned query params.
+    /// Anonymous requests are gated by stored bucket/object ACL, not auto-denied.
+    pub is_anonymous: bool,
+}
+
+/// Static admin display name, e.g. for `<Owner><DisplayName>` in ACL XML.
+/// Defaults to match `s3-tests.conf`'s `[s3 main] display_name`.
+pub fn admin_display_name() -> String {
+    std::env::var("WARPDRIVE_ADMIN_DISPLAY_NAME")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "Warpdrive Admin".to_string())
 }
 
 /// Returns (base_url, service_secret, cache_ttl_secs).
@@ -420,7 +441,7 @@ fn verify_sigv4(
             canonical_uri,
             canonical_query_string.len()
         );
-        return Err(ErrorUnauthorized("Signature does not match"));
+        return Err(s3_access_denied("Signature does not match"));
     }
     Ok(())
 }
@@ -654,7 +675,7 @@ fn verify_sigv4_presigned(req: &HttpRequest, secret_key: &str, parsed: &ParsedPr
     })?;
     if mac.verify_slice(&provided_sig).is_err() {
         warn!("Presigned V4 signature mismatch (uri={}, query_len={})", canonical_uri, canonical_query_string.len());
-        return Err(ErrorUnauthorized("Signature does not match"));
+        return Err(s3_access_denied("Signature does not match"));
     }
     Ok(())
 }
@@ -675,18 +696,20 @@ async fn authenticate_presigned_v4(req: &HttpRequest, query: &HashMap<String, St
             debug!("Presigned V4 auth: admin bypass OK bucket={:?}", bucket);
             return Ok(S3AuthResult {
                 access_key,
-                user_id: "admin".to_string(),
+                user_id: ADMIN_USER_ID.to_string(),
+                owner_display_name: admin_display_name(),
                 bucket,
                 allowed_buckets: vec![],
                 allow_all_buckets: true,
+                is_anonymous: false,
             });
         }
     }
 
     // Console path
     let (base_url, service_secret, cache_ttl_secs) = auth_config_from_env();
-    let base_url = base_url.ok_or_else(|| ErrorUnauthorized("No authentication method configured"))?;
-    let service_secret = service_secret.ok_or_else(|| ErrorUnauthorized("WARPDRIVE_SERVICE_SECRET not set"))?;
+    let base_url = base_url.ok_or_else(|| s3_access_denied("No authentication method configured"))?;
+    let service_secret = service_secret.ok_or_else(|| s3_access_denied("WARPDRIVE_SERVICE_SECRET not set"))?;
     let (owner_id, secret_key, _, _) =
         load_or_refresh_credential_bundle(&access_key, &base_url, &service_secret, cache_ttl_secs).await?;
 
@@ -694,10 +717,12 @@ async fn authenticate_presigned_v4(req: &HttpRequest, query: &HashMap<String, St
     debug!("Presigned V4 auth: Console OK bucket={:?} user={}", bucket, owner_id);
     Ok(S3AuthResult {
         access_key,
+        owner_display_name: owner_id.clone(),
         user_id: owner_id,
         bucket,
         allowed_buckets: vec![],
         allow_all_buckets: false,
+        is_anonymous: false,
     })
 }
 
@@ -729,28 +754,32 @@ fn s3_access_denied(message: &str) -> Error {
     ).into()
 }
 
+/// Authenticate an S3 request, requiring valid credentials — a missing Authorization
+/// header is always a 403, exactly like before ACL support existed. This is what the
+/// vast majority of handlers should keep using unchanged.
 pub async fn authenticate_s3_request(req: &HttpRequest) -> Result<S3AuthResult, Error> {
+    authenticate_s3_request_inner(req, false).await
+}
+
+/// Same as `authenticate_s3_request`, but a missing Authorization header returns an
+/// `Ok(S3AuthResult { is_anonymous: true, .. })` instead of erroring, so the caller can
+/// gate the request against the resource's stored ACL (public-read/public-read-write/
+/// authenticated-read) instead of rejecting it outright. Only handlers that actually
+/// implement an ACL check for anonymous access should call this — everything else
+/// should keep using `authenticate_s3_request`.
+pub async fn authenticate_s3_request_allow_anonymous(req: &HttpRequest) -> Result<S3AuthResult, Error> {
+    authenticate_s3_request_inner(req, true).await
+}
+
+async fn authenticate_s3_request_inner(req: &HttpRequest, allow_anonymous: bool) -> Result<S3AuthResult, Error> {
     // Detect presigned requests before looking for Authorization header
     let query_map = parse_query_map(req);
     if query_map.contains_key("X-Amz-Algorithm") {
         return authenticate_presigned_v4(req, &query_map).await;
     }
 
-    let auth_header = req
-        .headers()
-        .get("Authorization")
-        .ok_or_else(|| {
-            warn!("Missing Authorization header");
-            s3_access_denied("Access Denied")
-        })?
-        .to_str()
-        .map_err(|_| {
-            warn!("Invalid Authorization header format");
-            s3_access_denied("Access Denied")
-        })?;
+    let auth_header_opt = req.headers().get("Authorization").and_then(|v| v.to_str().ok());
 
-    let parsed = parse_authorization_header_full(auth_header)?;
-    let access_key = parsed.access_key.clone();
     let bucket = extract_bucket_from_path(req)?;
 
     if !is_list_buckets_request(req) && bucket.is_empty() {
@@ -763,6 +792,32 @@ pub async fn authenticate_s3_request(req: &HttpRequest) -> Result<S3AuthResult, 
             "S3 path must be /s3/{bucket}/... for this operation (use path-style addressing in your S3 client)",
         ));
     }
+
+    let auth_header = match auth_header_opt {
+        Some(h) => h,
+        None => {
+            if allow_anonymous {
+                // S3 never rejects this outright (e.g. anonymous ListBuckets returns 200
+                // with an empty list) — the caller gates on `is_anonymous` against the
+                // resource's stored ACL.
+                debug!("S3 auth: anonymous request path_bucket={:?}", bucket);
+                return Ok(S3AuthResult {
+                    access_key: String::new(),
+                    user_id: String::new(),
+                    owner_display_name: String::new(),
+                    bucket,
+                    allowed_buckets: vec![],
+                    allow_all_buckets: false,
+                    is_anonymous: true,
+                });
+            }
+            warn!("Missing Authorization header");
+            return Err(s3_access_denied("Access Denied"));
+        }
+    };
+
+    let parsed = parse_authorization_header_full(auth_header)?;
+    let access_key = parsed.access_key.clone();
 
     debug!(
         "S3 auth: request_path={} extracted_bucket={:?} list_buckets={}",
@@ -779,10 +834,12 @@ pub async fn authenticate_s3_request(req: &HttpRequest) -> Result<S3AuthResult, 
             debug!("S3 auth: admin bypass OK path_bucket={:?}", bucket);
             return Ok(S3AuthResult {
                 access_key,
-                user_id: "admin".to_string(),
+                user_id: ADMIN_USER_ID.to_string(),
+                owner_display_name: admin_display_name(),
                 bucket,
                 allowed_buckets: vec![],
                 allow_all_buckets: true,
+                is_anonymous: false,
             });
         }
     }
@@ -792,11 +849,11 @@ pub async fn authenticate_s3_request(req: &HttpRequest) -> Result<S3AuthResult, 
 
     let base_url = base_url.ok_or_else(|| {
         warn!("VITALITY_CONSOLE_URL not set and no admin credentials configured");
-        ErrorUnauthorized("No authentication method configured (set WARPDRIVE_ADMIN_ACCESS_KEY or VITALITY_CONSOLE_URL)")
+        s3_access_denied("No authentication method configured (set WARPDRIVE_ADMIN_ACCESS_KEY or VITALITY_CONSOLE_URL)")
     })?;
     let service_secret = service_secret.ok_or_else(|| {
         warn!("WARPDRIVE_SERVICE_SECRET not set");
-        ErrorUnauthorized("WARPDRIVE_SERVICE_SECRET must be set when using Vitality Console")
+        s3_access_denied("WARPDRIVE_SERVICE_SECRET must be set when using Vitality Console")
     })?;
 
     let (mut owner_id, mut secret_key, mut allowed_buckets, cache_hit) =
@@ -835,10 +892,12 @@ pub async fn authenticate_s3_request(req: &HttpRequest) -> Result<S3AuthResult, 
     );
     Ok(S3AuthResult {
         access_key,
+        owner_display_name: owner_id.clone(),
         user_id: owner_id,
         bucket,
         allowed_buckets: allowed_buckets_vec,
         allow_all_buckets: false,
+        is_anonymous: false,
     })
 }
 

--- a/server/src/s3/handlers/acl.rs
+++ b/server/src/s3/handlers/acl.rs
@@ -1,9 +1,380 @@
-// ACL stub handlers + validate_bucket_name + validate_object_key.
+// ACL: canned ACLs, header-based grants, arbitrary AccessControlPolicy XML bodies,
+// Block Public Access, and ACL-derived bucket policy status.
+//
+// Design note: permission checks below only ever gate *anonymous* requests (see
+// `authenticate_s3_request_allow_anonymous` in auth.rs). An authenticated request is
+// always the resource owner in today's single-admin setup, so it always gets full
+// access — matching the RFC's own scoping ("admin always has full access to
+// everything they own"). Grant-list storage never hardcodes "admin": it's built from
+// whatever `auth_result.user_id`/`owner_display_name` auth resolves to, so real
+// per-principal grant evaluation is a pure addition once Vitality Console (UAM)
+// resolves more than one identity — nothing here needs to change for that.
 use actix_web::{HttpRequest, HttpResponse, Error, http::StatusCode};
+use serde::{Deserialize, Serialize};
 
 use super::common::*;
 
-pub(super) async fn s3_get_object_acl_stub(bucket: &str, key: &str, req: &HttpRequest) -> Result<HttpResponse, Error> {
+pub(super) const URI_ALL_USERS: &str = "http://acs.amazonaws.com/groups/global/AllUsers";
+pub(super) const URI_AUTHENTICATED_USERS: &str = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub(super) enum Grantee {
+    CanonicalUser { id: String, display_name: Option<String> },
+    Group { uri: String },
+    Email { email: String },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub(super) enum Permission {
+    Read,
+    Write,
+    ReadAcp,
+    WriteAcp,
+    FullControl,
+}
+
+impl Permission {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Permission::Read => "READ",
+            Permission::Write => "WRITE",
+            Permission::ReadAcp => "READ_ACP",
+            Permission::WriteAcp => "WRITE_ACP",
+            Permission::FullControl => "FULL_CONTROL",
+        }
+    }
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "READ" => Some(Permission::Read),
+            "WRITE" => Some(Permission::Write),
+            "READ_ACP" => Some(Permission::ReadAcp),
+            "WRITE_ACP" => Some(Permission::WriteAcp),
+            "FULL_CONTROL" => Some(Permission::FullControl),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(super) struct AclGrant {
+    pub grantee: Grantee,
+    pub permission: Permission,
+}
+
+fn owner_grant(owner_id: &str, owner_display: &str) -> AclGrant {
+    AclGrant {
+        grantee: Grantee::CanonicalUser {
+            id: owner_id.to_string(),
+            display_name: Some(owner_display.to_string()),
+        },
+        permission: Permission::FullControl,
+    }
+}
+
+/// Expand a canned ACL keyword into its grant list. `bucket-owner-read` /
+/// `bucket-owner-full-control` only differ from `private` when the object owner isn't
+/// the bucket owner — unreachable without a second real identity, so they resolve to
+/// owner-FULL_CONTROL for now (the tests that would distinguish them are deferred).
+pub(super) fn expand_canned(canned: &str, owner_id: &str, owner_display: &str) -> Result<Vec<AclGrant>, HttpResponse> {
+    let owner = owner_grant(owner_id, owner_display);
+    match canned {
+        "private" | "bucket-owner-read" | "bucket-owner-full-control" => Ok(vec![owner]),
+        "public-read" => Ok(vec![
+            AclGrant { grantee: Grantee::Group { uri: URI_ALL_USERS.to_string() }, permission: Permission::Read },
+            owner,
+        ]),
+        "public-read-write" => Ok(vec![
+            AclGrant { grantee: Grantee::Group { uri: URI_ALL_USERS.to_string() }, permission: Permission::Read },
+            AclGrant { grantee: Grantee::Group { uri: URI_ALL_USERS.to_string() }, permission: Permission::Write },
+            owner,
+        ]),
+        "authenticated-read" => Ok(vec![
+            AclGrant { grantee: Grantee::Group { uri: URI_AUTHENTICATED_USERS.to_string() }, permission: Permission::Read },
+            owner,
+        ]),
+        _ => Err(s3_error(StatusCode::BAD_REQUEST, "InvalidArgument",
+                          "Invalid canned ACL", canned)),
+    }
+}
+
+fn parse_grantee_spec(spec: &str) -> Option<Grantee> {
+    let (k, v) = spec.split_once('=')?;
+    let v = v.trim().trim_matches('"').to_string();
+    match k.trim() {
+        "id" => Some(Grantee::CanonicalUser { id: v, display_name: None }),
+        "uri" => Some(Grantee::Group { uri: v }),
+        "emailAddress" => Some(Grantee::Email { email: v }),
+        _ => None,
+    }
+}
+
+/// Parse `x-amz-grant-{read,write,read-acp,write-acp,full-control}` headers. Each
+/// value is a comma-separated list of `id=...` / `uri=...` / `emailAddress=...`
+/// grantee specs (AWS spec). Returns `None` when no grant headers are present at all
+/// (caller falls back to canned ACL / XML body / default-private). When present,
+/// header grants *replace* the grant list entirely — no implicit owner grant is added,
+/// confirmed by the Ceph tests (`test_object_header_acl_grants` etc. expect exactly
+/// the granted permissions, no separate owner entry).
+pub(super) fn grants_from_headers(req: &HttpRequest) -> Option<Result<Vec<AclGrant>, HttpResponse>> {
+    let header_perms = [
+        ("x-amz-grant-read", Permission::Read),
+        ("x-amz-grant-write", Permission::Write),
+        ("x-amz-grant-read-acp", Permission::ReadAcp),
+        ("x-amz-grant-write-acp", Permission::WriteAcp),
+        ("x-amz-grant-full-control", Permission::FullControl),
+    ];
+    let mut any = false;
+    let mut grants = Vec::new();
+    for (header, perm) in header_perms {
+        if let Some(val) = req.headers().get(header).and_then(|v| v.to_str().ok()) {
+            any = true;
+            for spec in val.split(',') {
+                let spec = spec.trim();
+                if spec.is_empty() { continue; }
+                match parse_grantee_spec(spec) {
+                    Some(Grantee::Email { .. }) => {
+                        // No email→canonical-ID directory in static-admin mode.
+                        return Some(Err(s3_error(StatusCode::BAD_REQUEST, "InvalidArgument",
+                                                 "The specified email address does not resolve to an account",
+                                                 spec)));
+                    }
+                    Some(grantee) => grants.push(AclGrant { grantee, permission: perm }),
+                    None => return Some(Err(s3_error(StatusCode::BAD_REQUEST, "InvalidArgument",
+                                                       "Invalid grantee specification", spec))),
+                }
+            }
+        }
+    }
+    if !any { return None; }
+    Some(Ok(grants))
+}
+
+/// Find `<tag ...>...</tag>` (attributes on the opening tag, unlike `extract_xml_tag`
+/// which only matches a bare `<tag>`) and return the whole block including both tags.
+fn extract_tag_block(src: &str, tag: &str) -> Option<String> {
+    let open_marker = format!("<{}", tag);
+    let open_start = src.find(&open_marker)?;
+    let after = &src[open_start..];
+    let close_tag = format!("</{}>", tag);
+    let close_start = after.find(&close_tag)?;
+    Some(after[..close_start + close_tag.len()].to_string())
+}
+
+fn parse_grantee_block(full_block: &str) -> Option<Grantee> {
+    let open_end = full_block.find('>')?;
+    let open_tag = &full_block[..open_end];
+    let inner = &full_block[open_end + 1..full_block.rfind("</Grantee>")?];
+    if open_tag.contains("\"CanonicalUser\"") {
+        let id = extract_xml_tag(inner, "ID")?;
+        let display_name = extract_xml_tag(inner, "DisplayName");
+        Some(Grantee::CanonicalUser { id, display_name })
+    } else if open_tag.contains("\"Group\"") {
+        let uri = extract_xml_tag(inner, "URI")?;
+        Some(Grantee::Group { uri })
+    } else if open_tag.contains("AmazonCustomerByEmail") {
+        let email = extract_xml_tag(inner, "EmailAddress")?;
+        Some(Grantee::Email { email })
+    } else {
+        None
+    }
+}
+
+/// Parse an explicit `AccessControlPolicy` XML body (`PUT ?acl` with a body instead of
+/// canned/header grants). An empty `<AccessControlList/>` parses to an empty grant
+/// list, stored verbatim (`test_bucket_acl_revoke_all`).
+pub(super) fn parse_acl_xml(body: &str) -> Result<Vec<AclGrant>, HttpResponse> {
+    let acl_block = extract_xml_tag(body, "AccessControlList").unwrap_or_default();
+    let mut grants = Vec::new();
+    for block in extract_all_xml_tags(&acl_block, "Grant") {
+        let permission_str = extract_xml_tag(&block, "Permission").unwrap_or_default();
+        let permission = Permission::from_str(&permission_str)
+            .ok_or_else(|| s3_error(StatusCode::BAD_REQUEST, "MalformedACLError",
+                                    "Invalid permission in ACL", &permission_str))?;
+        let grantee_block = extract_tag_block(&block, "Grantee")
+            .ok_or_else(|| s3_error(StatusCode::BAD_REQUEST, "MalformedACLError",
+                                    "Missing Grantee in ACL grant", ""))?;
+        let grantee = parse_grantee_block(&grantee_block)
+            .ok_or_else(|| s3_error(StatusCode::BAD_REQUEST, "InvalidArgument",
+                                    "Invalid grantee in ACL", ""))?;
+        grants.push(AclGrant { grantee, permission });
+    }
+    Ok(grants)
+}
+
+/// Reorder so the owner's own CanonicalUser grant sorts last. Every achievable Ceph
+/// ACL test expects group/public grants before the owner's FULL_CONTROL entry
+/// (`test_bucket_acl_canned`, `test_put_bucket_acl_grant_group_read`, etc.) — `boto3`'s
+/// `check_grants` test helper only tolerates arbitrary ordering when every grant has a
+/// DisplayName, which isn't true here (group grants don't), so exact positional order
+/// matters.
+fn normalize_grant_order(grants: Vec<AclGrant>, owner_id: &str) -> Vec<AclGrant> {
+    let (owner, rest): (Vec<_>, Vec<_>) = grants.into_iter().partition(|g| {
+        matches!(&g.grantee, Grantee::CanonicalUser { id, .. } if id == owner_id)
+            && g.permission == Permission::FullControl
+    });
+    let mut out = rest;
+    out.extend(owner);
+    out
+}
+
+fn grants_to_xml(owner_id: &str, owner_display: &str, grants: &[AclGrant]) -> String {
+    let mut grants_xml = String::new();
+    for g in grants {
+        let grantee_xml = match &g.grantee {
+            Grantee::CanonicalUser { id, display_name } => format!(
+                "<Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"CanonicalUser\">\
+                 <ID>{}</ID><DisplayName>{}</DisplayName></Grantee>",
+                xml_escape(id), xml_escape(display_name.as_deref().unwrap_or(id))
+            ),
+            Grantee::Group { uri } => format!(
+                "<Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"Group\">\
+                 <URI>{}</URI></Grantee>",
+                xml_escape(uri)
+            ),
+            Grantee::Email { email } => format!(
+                "<Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"AmazonCustomerByEmail\">\
+                 <EmailAddress>{}</EmailAddress></Grantee>",
+                xml_escape(email)
+            ),
+        };
+        grants_xml.push_str(&format!(
+            "<Grant>{}<Permission>{}</Permission></Grant>",
+            grantee_xml, g.permission.as_str()
+        ));
+    }
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <AccessControlPolicy xmlns=\"{s3}\">\
+           <Owner><ID>{oid}</ID><DisplayName>{odn}</DisplayName></Owner>\
+           <AccessControlList>{grants}</AccessControlList>\
+         </AccessControlPolicy>",
+        s3 = S3_XMLNS, oid = xml_escape(owner_id), odn = xml_escape(owner_display), grants = grants_xml,
+    )
+}
+
+pub(super) fn grants_to_json(grants: &[AclGrant]) -> String {
+    serde_json::to_string(grants).unwrap_or_else(|_| "[]".to_string())
+}
+
+pub(super) fn grants_from_json(json: &str) -> Vec<AclGrant> {
+    serde_json::from_str(json).unwrap_or_default()
+}
+
+/// Precedence: `x-amz-grant-*` headers > `x-amz-acl` canned header > XML body >
+/// default-private. Real S3 rejects both a canned header and grant headers together.
+pub(super) fn resolve_effective_grants(
+    req: &HttpRequest,
+    body: Option<&str>,
+    owner_id: &str,
+    owner_display: &str,
+) -> Result<Vec<AclGrant>, HttpResponse> {
+    let canned = req.headers().get("x-amz-acl").and_then(|v| v.to_str().ok());
+    let header_grants = grants_from_headers(req);
+
+    let grants = match (canned, header_grants) {
+        (Some(_), Some(_)) => {
+            return Err(s3_error(StatusCode::BAD_REQUEST, "InvalidArgument",
+                                "Specify only one of x-amz-acl or x-amz-grant-*", ""));
+        }
+        (_, Some(hg)) => hg?,
+        (Some(c), None) => expand_canned(c, owner_id, owner_display)?,
+        (None, None) => match body.filter(|b| !b.trim().is_empty()) {
+            Some(b) => parse_acl_xml(b)?,
+            None => expand_canned("private", owner_id, owner_display)?,
+        },
+    };
+    Ok(normalize_grant_order(grants, owner_id))
+}
+
+pub(super) fn grants_contain_group(grants: &[AclGrant], uri: &str, perms: &[Permission]) -> bool {
+    grants.iter().any(|g| {
+        matches!(&g.grantee, Grantee::Group { uri: u } if u == uri)
+            && perms.contains(&g.permission)
+    })
+}
+
+const READABLE: [Permission; 2] = [Permission::Read, Permission::FullControl];
+const WRITABLE: [Permission; 2] = [Permission::Write, Permission::FullControl];
+
+pub(super) fn is_publicly_readable(grants: &[AclGrant]) -> bool {
+    grants_contain_group(grants, URI_ALL_USERS, &READABLE)
+}
+
+pub(super) fn is_publicly_writable(grants: &[AclGrant]) -> bool {
+    grants_contain_group(grants, URI_ALL_USERS, &WRITABLE)
+}
+
+pub(super) fn is_authenticated_readable(grants: &[AclGrant]) -> bool {
+    grants_contain_group(grants, URI_AUTHENTICATED_USERS, &READABLE)
+}
+
+/// True if any grant hands anything to AllUsers/AuthenticatedUsers, regardless of
+/// permission — used for Block Public Access's `block_public_acls` rejection (real S3
+/// rejects `authenticated-read` too, not just public-read/public-read-write).
+pub(super) fn grants_contain_public(grants: &[AclGrant]) -> bool {
+    grants.iter().any(|g| matches!(&g.grantee, Grantee::Group { uri }
+        if uri == URI_ALL_USERS || uri == URI_AUTHENTICATED_USERS))
+}
+
+/// Reject storing a public grant when the bucket's Block Public Access has
+/// `block_public_acls` set (`test_block_public_put_bucket_acls`,
+/// `test_block_public_object_canned_acls`).
+fn check_block_public_acls(db: &crate::service::metadata_service::MetadataService, bucket: &str, grants: &[AclGrant]) -> Result<(), HttpResponse> {
+    if let Ok(Some((block_public_acls, _, _, _))) = db.get_public_access_block(bucket) {
+        if block_public_acls && grants_contain_public(grants) {
+            return Err(s3_error(StatusCode::FORBIDDEN, "AccessDenied",
+                                "Public access blocked for this bucket", bucket));
+        }
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Bucket ACL  GET/PUT /s3/{bucket}?acl
+// ---------------------------------------------------------------------------
+
+pub(super) async fn s3_get_bucket_acl_inner(bucket: &str, req: &HttpRequest) -> Result<HttpResponse, Error> {
+    use crate::s3::auth::authenticate_s3_request;
+    use crate::service::metadata_service::MetadataService;
+
+    let auth_result = authenticate_s3_request(req).await?;
+    let db = MetadataService::new(&auth_result.user_id)?;
+    if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
+
+    let (owner_id, grants) = match db.get_bucket_acl(bucket) {
+        Ok(Some((owner_id, grants_json))) => (owner_id, grants_from_json(&grants_json)),
+        _ => (auth_result.user_id.clone(), expand_canned("private", &auth_result.user_id, &auth_result.owner_display_name).unwrap_or_default()),
+    };
+    let owner_display = if owner_id == auth_result.user_id { auth_result.owner_display_name.clone() } else { owner_id.clone() };
+    let xml = grants_to_xml(&owner_id, &owner_display, &grants);
+    Ok(HttpResponse::Ok().content_type("application/xml").body(xml))
+}
+
+pub(super) async fn s3_put_bucket_acl_inner(bucket: &str, body: &[u8], req: &HttpRequest) -> Result<HttpResponse, Error> {
+    use crate::s3::auth::authenticate_s3_request;
+    use crate::service::metadata_service::MetadataService;
+
+    let auth_result = authenticate_s3_request(req).await?;
+    let db = MetadataService::new(&auth_result.user_id)?;
+    if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
+
+    let body_str = String::from_utf8_lossy(body);
+    let grants = match resolve_effective_grants(req, Some(&body_str), &auth_result.user_id, &auth_result.owner_display_name) {
+        Ok(g) => g,
+        Err(resp) => return Ok(resp),
+    };
+    if let Err(resp) = check_block_public_acls(&db, bucket, &grants) { return Ok(resp); }
+
+    db.set_bucket_acl(bucket, &auth_result.user_id, &grants_to_json(&grants))?;
+    Ok(HttpResponse::Ok().insert_header(("Content-Length", "0")).body(""))
+}
+
+// ---------------------------------------------------------------------------
+// Object ACL  GET/PUT /s3/{bucket}/{key}?acl
+// ---------------------------------------------------------------------------
+
+pub(super) async fn s3_get_object_acl_inner(bucket: &str, key: &str, req: &HttpRequest) -> Result<HttpResponse, Error> {
     use crate::s3::auth::authenticate_s3_request;
     use crate::service::metadata_service::MetadataService;
 
@@ -14,54 +385,133 @@ pub(super) async fn s3_get_object_acl_stub(bucket: &str, key: &str, req: &HttpRe
         return Ok(s3_error(StatusCode::NOT_FOUND, "NoSuchKey",
                            "The specified key does not exist.", &format!("/{}/{}", bucket, key)));
     }
-    let owner_id = xml_escape(&auth_result.user_id);
-    let xml = format!(
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-         <AccessControlPolicy xmlns=\"{s3}\">\n\
-           <Owner><ID>{id}</ID><DisplayName>{id}</DisplayName></Owner>\n\
-           <AccessControlList>\n\
-             <Grant>\n\
-               <Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"CanonicalUser\">\
-                 <ID>{id}</ID><DisplayName>{id}</DisplayName></Grantee>\n\
-               <Permission>FULL_CONTROL</Permission>\n\
-             </Grant>\n\
-           </AccessControlList>\n\
-         </AccessControlPolicy>",
-        s3 = S3_XMLNS, id = owner_id,
-    );
+
+    let (owner_id, grants) = match db.get_object_acl(bucket, key, "") {
+        Ok(Some((owner_id, grants_json))) => (owner_id, grants_from_json(&grants_json)),
+        _ => (auth_result.user_id.clone(), expand_canned("private", &auth_result.user_id, &auth_result.owner_display_name).unwrap_or_default()),
+    };
+    let owner_display = if owner_id == auth_result.user_id { auth_result.owner_display_name.clone() } else { owner_id.clone() };
+    let xml = grants_to_xml(&owner_id, &owner_display, &grants);
     Ok(HttpResponse::Ok().content_type("application/xml").body(xml))
 }
 
-pub(super) async fn s3_get_bucket_acl_stub(bucket: &str, req: &HttpRequest) -> Result<HttpResponse, Error> {
+pub(super) async fn s3_put_object_acl_inner(bucket: &str, key: &str, body: &[u8], req: &HttpRequest) -> Result<HttpResponse, Error> {
     use crate::s3::auth::authenticate_s3_request;
     use crate::service::metadata_service::MetadataService;
 
     let auth_result = authenticate_s3_request(req).await?;
     let db = MetadataService::new(&auth_result.user_id)?;
     if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
-    let owner_id = xml_escape(&auth_result.user_id);
-    let xml = format!(
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
-         <AccessControlPolicy xmlns=\"{s3}\">\n\
-           <Owner><ID>{id}</ID><DisplayName>{id}</DisplayName></Owner>\n\
-           <AccessControlList>\n\
-             <Grant>\n\
-               <Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"CanonicalUser\">\
-                 <ID>{id}</ID><DisplayName>{id}</DisplayName></Grantee>\n\
-               <Permission>FULL_CONTROL</Permission>\n\
-             </Grant>\n\
-           </AccessControlList>\n\
-         </AccessControlPolicy>",
-        s3 = S3_XMLNS, id = owner_id,
-    );
-    Ok(HttpResponse::Ok().content_type("application/xml").body(xml))
+    if !db.check_key(bucket, key)? {
+        return Ok(s3_error(StatusCode::NOT_FOUND, "NoSuchKey",
+                           "The specified key does not exist.", &format!("/{}/{}", bucket, key)));
+    }
+
+    let body_str = String::from_utf8_lossy(body);
+    let grants = match resolve_effective_grants(req, Some(&body_str), &auth_result.user_id, &auth_result.owner_display_name) {
+        Ok(g) => g,
+        Err(resp) => return Ok(resp),
+    };
+    if let Err(resp) = check_block_public_acls(&db, bucket, &grants) { return Ok(resp); }
+
+    db.set_object_acl(bucket, key, "", &auth_result.user_id, &grants_to_json(&grants))?;
+    Ok(HttpResponse::Ok().insert_header(("Content-Length", "0")).body(""))
 }
 
-/// PUT ?acl on bucket or object — accept and ignore.
-pub(super) async fn s3_put_acl_stub(req: &HttpRequest) -> Result<HttpResponse, Error> {
+// ---------------------------------------------------------------------------
+// Block Public Access  GET/PUT/DELETE /s3/{bucket}?publicAccessBlock
+// ---------------------------------------------------------------------------
+
+pub(super) async fn s3_get_public_access_block_inner(bucket: &str, req: &HttpRequest) -> Result<HttpResponse, Error> {
     use crate::s3::auth::authenticate_s3_request;
-    let _auth = authenticate_s3_request(req).await?;
+    use crate::service::metadata_service::MetadataService;
+
+    let auth_result = authenticate_s3_request(req).await?;
+    let db = MetadataService::new(&auth_result.user_id)?;
+    if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
+
+    match db.get_public_access_block(bucket) {
+        Ok(Some((a, i, p, r))) => {
+            let b = |v: bool| if v { "true" } else { "false" };
+            let xml = format!(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+                 <PublicAccessBlockConfiguration xmlns=\"{s3}\">\
+                   <BlockPublicAcls>{a}</BlockPublicAcls>\
+                   <IgnorePublicAcls>{i}</IgnorePublicAcls>\
+                   <BlockPublicPolicy>{p}</BlockPublicPolicy>\
+                   <RestrictPublicBuckets>{r}</RestrictPublicBuckets>\
+                 </PublicAccessBlockConfiguration>",
+                s3 = S3_XMLNS, a = b(a), i = b(i), p = b(p), r = b(r),
+            );
+            Ok(HttpResponse::Ok().content_type("application/xml").body(xml))
+        }
+        _ => Ok(s3_error(StatusCode::NOT_FOUND, "NoSuchPublicAccessBlockConfiguration",
+                         "The public access block configuration was not found", bucket)),
+    }
+}
+
+pub(super) async fn s3_put_public_access_block_inner(bucket: &str, body: &[u8], req: &HttpRequest) -> Result<HttpResponse, Error> {
+    use crate::s3::auth::authenticate_s3_request;
+    use crate::service::metadata_service::MetadataService;
+
+    let auth_result = authenticate_s3_request(req).await?;
+    let db = MetadataService::new(&auth_result.user_id)?;
+    if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
+
+    let body_str = String::from_utf8_lossy(body);
+    let flag = |tag: &str| extract_xml_tag(&body_str, tag)
+        .map(|v| v.trim().eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    db.set_public_access_block(
+        bucket,
+        flag("BlockPublicAcls"),
+        flag("IgnorePublicAcls"),
+        flag("BlockPublicPolicy"),
+        flag("RestrictPublicBuckets"),
+    )?;
     Ok(HttpResponse::Ok().insert_header(("Content-Length", "0")).body(""))
+}
+
+pub(super) async fn s3_delete_public_access_block_inner(bucket: &str, req: &HttpRequest) -> Result<HttpResponse, Error> {
+    use crate::s3::auth::authenticate_s3_request;
+    use crate::service::metadata_service::MetadataService;
+
+    let auth_result = authenticate_s3_request(req).await?;
+    let db = MetadataService::new(&auth_result.user_id)?;
+    if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
+
+    db.delete_public_access_block(bucket)?;
+    Ok(HttpResponse::NoContent().insert_header(("Content-Length", "0")).body(""))
+}
+
+// ---------------------------------------------------------------------------
+// Bucket policy status (ACL-derived only — no bucket policy engine yet)
+// GET /s3/{bucket}?policyStatus
+// ---------------------------------------------------------------------------
+
+pub(super) async fn s3_get_bucket_policy_status_inner(bucket: &str, req: &HttpRequest) -> Result<HttpResponse, Error> {
+    use crate::s3::auth::authenticate_s3_request;
+    use crate::service::metadata_service::MetadataService;
+
+    let auth_result = authenticate_s3_request(req).await?;
+    let db = MetadataService::new(&auth_result.user_id)?;
+    if let Err(resp) = require_bucket(&db, bucket) { return Ok(resp); }
+
+    let grants = match db.get_bucket_acl(bucket) {
+        Ok(Some((_, grants_json))) => grants_from_json(&grants_json),
+        _ => Vec::new(),
+    };
+    let ignore_public_acls = matches!(db.get_public_access_block(bucket), Ok(Some((_, true, _, _))));
+    let is_public = !ignore_public_acls && (is_publicly_readable(&grants) || is_authenticated_readable(&grants)
+        || is_publicly_writable(&grants));
+
+    let xml = format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+         <PolicyStatus xmlns=\"{s3}\"><IsPublic>{p}</IsPublic></PolicyStatus>",
+        s3 = S3_XMLNS, p = is_public,
+    );
+    Ok(HttpResponse::Ok().content_type("application/xml").body(xml))
 }
 
 /// Validate S3 bucket name rules.
@@ -74,13 +524,20 @@ pub(super) fn validate_bucket_name(bucket: &str) -> Result<(), HttpResponse> {
         return Err(s3_error(StatusCode::BAD_REQUEST, "InvalidBucketName",
                             "Bucket name cannot start or end with . or -", bucket));
     }
-    if bucket.contains("..") || bucket.contains("--") {
+    if bucket.contains("..") || bucket.contains("--") || bucket.contains(".-") || bucket.contains("-.") {
         return Err(s3_error(StatusCode::BAD_REQUEST, "InvalidBucketName",
-                            "Bucket name cannot contain consecutive . or -", bucket));
+                            "Bucket name cannot contain consecutive . or -, or mix . and - adjacently", bucket));
     }
     if !bucket.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '-') {
         return Err(s3_error(StatusCode::BAD_REQUEST, "InvalidBucketName",
                             "Bucket name must only contain lowercase letters, numbers, hyphens, or dots", bucket));
+    }
+    // Reject names that look like an IPv4 address (e.g. "192.168.5.123") — real S3
+    // rejects these since they'd be ambiguous with virtual-hosted-style IP endpoints.
+    let octets: Vec<&str> = bucket.split('.').collect();
+    if octets.len() == 4 && octets.iter().all(|o| !o.is_empty() && o.chars().all(|c| c.is_ascii_digit()) && o.parse::<u32>().map(|n| n <= 255).unwrap_or(false)) {
+        return Err(s3_error(StatusCode::BAD_REQUEST, "InvalidBucketName",
+                            "Bucket name cannot be formatted as an IP address", bucket));
     }
     Ok(())
 }
@@ -97,3 +554,4 @@ pub(super) fn validate_object_key(key: &str, bucket: &str) -> Result<(), HttpRes
     }
     Ok(())
 }
+

--- a/server/src/s3/handlers/bucket.rs
+++ b/server/src/s3/handlers/bucket.rs
@@ -5,13 +5,13 @@ use log::info;
 
 use std::collections::HashMap;
 
-use crate::s3::auth::authenticate_s3_request;
+use crate::s3::auth::{authenticate_s3_request, authenticate_s3_request_allow_anonymous};
 use crate::service::metadata_service::MetadataService;
 
 use super::common::*;
 use super::tagging::{s3_put_bucket_tagging_inner, s3_delete_bucket_tagging_inner};
 use super::versioning::s3_put_bucket_versioning_inner;
-use super::acl::{s3_put_acl_stub, validate_bucket_name};
+use super::acl::{s3_put_bucket_acl_inner, s3_put_public_access_block_inner, s3_delete_public_access_block_inner, resolve_effective_grants, grants_to_json, validate_bucket_name};
 use super::object_lock::s3_put_bucket_object_lock_inner;
 
 // ---------------------------------------------------------------------------
@@ -22,10 +22,23 @@ pub async fn s3_list_buckets_handler(
     query: web::Query<HashMap<String, String>>,
     req: HttpRequest,
 ) -> Result<HttpResponse, Error> {
-    let auth_result = authenticate_s3_request(&req).await?;
+    let auth_result = authenticate_s3_request_allow_anonymous(&req).await?;
     if !auth_result.bucket.is_empty() {
         return Ok(s3_error(StatusCode::BAD_REQUEST, "InvalidRequest",
                            "Unexpected bucket in path for list-buckets", "/"));
+    }
+    if auth_result.is_anonymous {
+        // S3 doesn't reject anonymous ListBuckets — the anonymous principal just owns
+        // no buckets, so the response is a valid, empty list.
+        let xml = format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
+             <ListAllMyBucketsResult xmlns=\"{s3}\">\n\
+                 <Owner><ID></ID><DisplayName></DisplayName></Owner>\n\
+                 <Buckets></Buckets>\n\
+             </ListAllMyBucketsResult>",
+            s3 = S3_XMLNS,
+        );
+        return Ok(HttpResponse::Ok().content_type("application/xml").body(xml));
     }
     info!("S3 ListBuckets: user={}", auth_result.user_id);
 
@@ -78,14 +91,15 @@ pub async fn s3_list_buckets_handler(
     };
 
     let owner_id = xml_escape(&auth_result.user_id);
+    let owner_display = xml_escape(&auth_result.owner_display_name);
     let xml = format!(
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n\
          <ListAllMyBucketsResult xmlns=\"{s3}\">\n\
-             <Owner><ID>{owner}</ID><DisplayName>{owner}</DisplayName></Owner>\n\
+             <Owner><ID>{owner}</ID><DisplayName>{owner_dn}</DisplayName></Owner>\n\
              <Buckets>\n{buckets}</Buckets>\n\
              {continuation}\
          </ListAllMyBucketsResult>",
-        s3 = S3_XMLNS, owner = owner_id, buckets = buckets_xml,
+        s3 = S3_XMLNS, owner = owner_id, owner_dn = owner_display, buckets = buckets_xml,
         continuation = continuation_xml,
     );
     Ok(HttpResponse::Ok().content_type("application/xml").body(xml))
@@ -105,13 +119,18 @@ pub async fn s3_create_bucket_handler(
     let qmap: HashMap<String, String> = web::Query::<HashMap<String, String>>::from_query(req.query_string())
         .map(|q| q.into_inner()).unwrap_or_default();
 
-    if qmap.contains_key("acl") {
-        return s3_put_acl_stub(&req).await;
-    }
-    if qmap.contains_key("tagging") || qmap.contains_key("versioning") || qmap.contains_key("object-lock") {
+    if qmap.contains_key("acl") || qmap.contains_key("tagging") || qmap.contains_key("versioning")
+        || qmap.contains_key("object-lock") || qmap.contains_key("publicAccessBlock")
+    {
         let mut body: Vec<u8> = Vec::new();
         while let Some(chunk) = payload.next().await {
             body.extend_from_slice(&chunk.map_err(actix_web::error::ErrorInternalServerError)?);
+        }
+        if qmap.contains_key("acl") {
+            return s3_put_bucket_acl_inner(&bucket, &body, &req).await;
+        }
+        if qmap.contains_key("publicAccessBlock") {
+            return s3_put_public_access_block_inner(&bucket, &body, &req).await;
         }
         if qmap.contains_key("tagging") {
             return s3_put_bucket_tagging_inner(&bucket, &body, &req).await;
@@ -161,6 +180,18 @@ pub async fn s3_create_bucket_handler(
         db.set_bucket_location(&bucket, &location)?;
     }
 
+    // Only store an ACL row when the request actually specifies one — otherwise the
+    // ACL handlers synthesize the private-owner-only default at read time.
+    let has_acl_header = req.headers().contains_key("x-amz-acl")
+        || ["x-amz-grant-read", "x-amz-grant-write", "x-amz-grant-read-acp", "x-amz-grant-write-acp", "x-amz-grant-full-control"]
+            .iter().any(|h| req.headers().contains_key(*h));
+    if has_acl_header {
+        match resolve_effective_grants(&req, None, &auth_result.user_id, &auth_result.owner_display_name) {
+            Ok(grants) => db.set_bucket_acl(&bucket, &auth_result.user_id, &grants_to_json(&grants))?,
+            Err(resp) => return Ok(resp),
+        }
+    }
+
     info!("S3 CreateBucket: bucket={} user={} location={:?}", bucket, auth_result.user_id, location);
     Ok(HttpResponse::Ok()
         .insert_header(("Location", format!("/{}", bucket)))
@@ -192,6 +223,10 @@ pub async fn s3_delete_bucket_handler(
 
     if query.contains_key("tagging") {
         return s3_delete_bucket_tagging_inner(&bucket, &req).await;
+    }
+
+    if query.contains_key("publicAccessBlock") {
+        return s3_delete_public_access_block_inner(&bucket, &req).await;
     }
 
     let auth_result = authenticate_s3_request(&req).await?;

--- a/server/src/s3/handlers/common.rs
+++ b/server/src/s3/handlers/common.rs
@@ -104,6 +104,18 @@ pub(super) fn require_bucket(db: &MetadataService, bucket: &str) -> Result<(), H
     }
 }
 
+/// If `x-amz-expected-bucket-owner` is present, reject with 403 unless it matches the
+/// bucket's actual owner. AWS enforces this independently of ACL/permission grants —
+/// notably it still applies to a publicly-readable/writable bucket.
+pub(super) fn check_expected_bucket_owner(req: &HttpRequest, actual_owner: &str, resource: &str) -> Result<(), HttpResponse> {
+    if let Some(expected) = req.headers().get("x-amz-expected-bucket-owner").and_then(|v| v.to_str().ok()) {
+        if expected != actual_owner {
+            return Err(s3_error(StatusCode::FORBIDDEN, "AccessDenied", "Access Denied", resource));
+        }
+    }
+    Ok(())
+}
+
 /// Split extent list into ≤ S3_GET_STREAM_CHUNK slices for streaming.
 pub(super) fn stream_slices(chunks: &[(u64, u64)]) -> Vec<(u64, u64)> {
     let mut out = Vec::new();

--- a/server/src/s3/handlers/copy.rs
+++ b/server/src/s3/handlers/copy.rs
@@ -12,6 +12,7 @@ use crate::service::user_context::UserContext;
 use crate::util::serializer::deserialize_offset_size;
 
 use super::common::*;
+use super::acl::{resolve_effective_grants, grants_to_json};
 
 // ---------------------------------------------------------------------------
 // CopyObject  PUT /s3/{dst_bucket}/{dst_key} with x-amz-copy-source header
@@ -154,6 +155,17 @@ pub async fn s3_copy_object_handler(
     let (copy_vid, copy_old_extents) = db.put_object_full(&dst_bucket, &dst_key, dst_meta)?;
     if !copy_old_extents.is_empty() {
         db.queue_deletion(&dst_bucket, &dst_key, &copy_old_extents).ok();
+    }
+
+    let has_acl_header = req.headers().contains_key("x-amz-acl")
+        || ["x-amz-grant-read", "x-amz-grant-write", "x-amz-grant-read-acp", "x-amz-grant-write-acp", "x-amz-grant-full-control"]
+            .iter().any(|h| req.headers().contains_key(*h));
+    if has_acl_header {
+        let dst_vid = copy_vid.as_deref().unwrap_or("");
+        match resolve_effective_grants(&req, None, &auth_result.user_id, &auth_result.owner_display_name) {
+            Ok(grants) => db.set_object_acl(&dst_bucket, &dst_key, dst_vid, &auth_result.user_id, &grants_to_json(&grants))?,
+            Err(resp) => return Ok(resp),
+        }
     }
 
     let xml = format!(

--- a/server/src/s3/handlers/listing.rs
+++ b/server/src/s3/handlers/listing.rs
@@ -5,14 +5,14 @@ use log::{info, warn};
 
 use std::collections::HashMap;
 
-use crate::s3::auth::authenticate_s3_request;
+use crate::s3::auth::{authenticate_s3_request, authenticate_s3_request_allow_anonymous, ADMIN_USER_ID};
 use crate::service::metadata_service::MetadataService;
 
 use super::common::*;
 use super::tagging::s3_get_bucket_tagging_inner;
 use super::versioning::{s3_get_bucket_versioning_inner, s3_list_object_versions_handler_inner};
 use super::cors::{s3_get_bucket_cors_inner, s3_get_bucket_location_inner};
-use super::acl::s3_get_bucket_acl_stub;
+use super::acl::{s3_get_bucket_acl_inner, s3_get_public_access_block_inner, s3_get_bucket_policy_status_inner, grants_from_json, is_publicly_readable};
 use super::multipart::s3_list_multipart_uploads_handler;
 use super::object_lock::s3_get_bucket_object_lock_inner;
 
@@ -53,11 +53,35 @@ pub async fn s3_list_objects_handler(
         return s3_get_bucket_object_lock_inner(&bucket, &req).await;
     }
     if query.contains_key("acl") {
-        return s3_get_bucket_acl_stub(&bucket, &req).await;
+        return s3_get_bucket_acl_inner(&bucket, &req).await;
+    }
+    if query.contains_key("publicAccessBlock") {
+        return s3_get_public_access_block_inner(&bucket, &req).await;
+    }
+    if query.contains_key("policyStatus") {
+        return s3_get_bucket_policy_status_inner(&bucket, &req).await;
     }
 
-    let auth_result = authenticate_s3_request(&req).await?;
-    let db = MetadataService::new(&auth_result.user_id)?;
+    let auth_result = authenticate_s3_request_allow_anonymous(&req).await?;
+    // Anonymous requests aren't tied to any owned bucket set — resolve against the
+    // single static admin owner (today's only possible bucket owner) so bucket
+    // existence/ACL checks work the same as an authenticated lookup would.
+    let owner_id = if auth_result.is_anonymous { ADMIN_USER_ID.to_string() } else { auth_result.user_id.clone() };
+    let owner_display = if owner_id == ADMIN_USER_ID { crate::s3::auth::admin_display_name() } else { auth_result.owner_display_name.clone() };
+    let db = MetadataService::new(&owner_id)?;
+
+    if let Err(resp) = check_expected_bucket_owner(&req, &owner_id, &bucket) { return Ok(resp); }
+
+    if auth_result.is_anonymous {
+        // Checked before bucket existence so a nonexistent bucket doesn't leak via a 404.
+        let is_public = match db.get_bucket_acl(&bucket) {
+            Ok(Some((_, grants_json))) => is_publicly_readable(&grants_from_json(&grants_json)),
+            _ => false,
+        };
+        if !is_public {
+            return Ok(s3_error(StatusCode::FORBIDDEN, "AccessDenied", "Access Denied", &bucket));
+        }
+    }
 
     if let Err(resp) = require_bucket(&db, &bucket) { return Ok(resp); }
 
@@ -103,7 +127,6 @@ pub async fn s3_list_objects_handler(
 
     let all_keys = db.list_objects(&bucket)?;
     let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%S.000Z").to_string();
-    let owner_id = auth_result.user_id.clone();
 
     let mut contents_xml   = String::new();
     let mut prefixes_xml   = String::new();
@@ -171,8 +194,8 @@ pub async fn s3_list_objects_handler(
             let disp_key = if url_encode { s3_url_encode(key) } else { xml_escape(key) };
 
             let owner_xml = if !is_v2 || fetch_owner {
-                format!("      <Owner><ID>{id}</ID><DisplayName>{id}</DisplayName></Owner>\n",
-                        id = xml_escape(&owner_id))
+                format!("      <Owner><ID>{id}</ID><DisplayName>{dn}</DisplayName></Owner>\n",
+                        id = xml_escape(&owner_id), dn = xml_escape(&owner_display))
             } else {
                 String::new()
             };

--- a/server/src/s3/handlers/multipart.rs
+++ b/server/src/s3/handlers/multipart.rs
@@ -704,18 +704,20 @@ pub(super) async fn s3_list_multipart_uploads_handler(bucket: &str, req: &HttpRe
     let mut uploads_xml = String::new();
     for upload in &uploads {
         let uid = xml_escape(&upload.user_id);
+        let udn = if upload.user_id == auth_result.user_id { &auth_result.owner_display_name } else { &upload.user_id };
         uploads_xml.push_str(&format!(
             "<Upload>\
               <Key>{key}</Key>\
               <UploadId>{upid}</UploadId>\
-              <Initiator><ID>{uid}</ID><DisplayName>{uid}</DisplayName></Initiator>\
-              <Owner><ID>{uid}</ID><DisplayName>{uid}</DisplayName></Owner>\
+              <Initiator><ID>{uid}</ID><DisplayName>{udn}</DisplayName></Initiator>\
+              <Owner><ID>{uid}</ID><DisplayName>{udn}</DisplayName></Owner>\
               <StorageClass>STANDARD</StorageClass>\
               <Initiated>{init}</Initiated>\
             </Upload>",
             key   = xml_escape(&upload.key),
             upid  = xml_escape(&upload.upload_id),
             uid   = uid,
+            udn   = xml_escape(udn),
             init  = xml_escape(&upload.initiated_at),
         ));
     }

--- a/server/src/s3/handlers/object.rs
+++ b/server/src/s3/handlers/object.rs
@@ -8,7 +8,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::metadata::Metadata;
-use crate::s3::auth::{authenticate_s3_request, create_authenticated_request};
+use crate::s3::auth::{authenticate_s3_request, authenticate_s3_request_allow_anonymous, create_authenticated_request, ADMIN_USER_ID};
 use crate::service::metadata_service::MetadataService;
 use crate::service::storage_service::StorageService;
 use crate::service::user_context::UserContext;
@@ -18,7 +18,7 @@ use super::checksum::{parse_checksum_headers, verify_checksum, ChecksumAlgorithm
 use super::common::*;
 use super::tagging::{s3_put_object_tagging_inner, s3_get_object_tagging_inner, s3_delete_object_tagging_inner, parse_url_tags, validate_tags};
 use super::versioning::{s3_get_object_version_handler, s3_delete_specific_version_handler};
-use super::acl::{s3_put_acl_stub, s3_get_object_acl_stub, validate_object_key};
+use super::acl::{s3_put_object_acl_inner, s3_get_object_acl_inner, resolve_effective_grants, grants_to_json, grants_from_json, is_publicly_writable, is_publicly_readable, validate_object_key};
 use super::copy::s3_copy_object_handler;
 use super::multipart::{s3_upload_part_handler, s3_upload_part_copy_handler, s3_abort_multipart_upload_handler, s3_get_object_attributes_handler, s3_get_part_handler, s3_head_part_handler};
 use super::object_lock::{s3_put_object_retention_inner, s3_get_object_retention_inner, s3_put_object_legal_hold_inner, s3_get_object_legal_hold_inner, compute_retain_until};
@@ -51,7 +51,12 @@ pub async fn s3_put_object_handler(
             return s3_put_object_tagging_inner(&bucket, &key, &body, &req).await;
         }
         if query.contains_key("acl") {
-            return s3_put_acl_stub(&req).await;
+            let (bucket, key) = path.into_inner();
+            let mut body: Vec<u8> = Vec::new();
+            while let Some(chunk) = payload.next().await {
+                body.extend_from_slice(&chunk.map_err(actix_web::error::ErrorInternalServerError)?);
+            }
+            return s3_put_object_acl_inner(&bucket, &key, &body, &req).await;
         }
         if query.contains_key("retention") || query.contains_key("legal-hold") {
             let (bucket, key) = path.into_inner();
@@ -70,15 +75,34 @@ pub async fn s3_put_object_handler(
     }
 
     let (bucket, key) = path.into_inner();
-    let auth_result = authenticate_s3_request(&req).await?;
+    let auth_result = authenticate_s3_request_allow_anonymous(&req).await?;
     let _authenticated_req = create_authenticated_request(&req, &auth_result);
 
-    let db = MetadataService::new(&auth_result.user_id)?;
+    // Anonymous requests aren't tied to an owned bucket — resolve against the single
+    // static admin owner (today's only possible bucket owner), same as listing.rs.
+    let owner_id = if auth_result.is_anonymous { ADMIN_USER_ID.to_string() } else { auth_result.user_id.clone() };
+    let db = MetadataService::new(&owner_id)?;
+
+    if let Err(resp) = check_expected_bucket_owner(&req, &owner_id, &format!("/{}/{}", bucket, key)) { return Ok(resp); }
+
+    if auth_result.is_anonymous {
+        // Object doesn't exist yet (or is being overwritten) — permission to create/
+        // overwrite it is a bucket-level WRITE grant, not an object-level one. Checked
+        // before bucket existence so a nonexistent bucket doesn't leak via a 404.
+        let bucket_writable = match db.get_bucket_acl(&bucket) {
+            Ok(Some((_, grants_json))) => is_publicly_writable(&grants_from_json(&grants_json)),
+            _ => false,
+        };
+        if !bucket_writable {
+            return Ok(s3_error(StatusCode::FORBIDDEN, "AccessDenied", "Access Denied", &format!("/{}/{}", bucket, key)));
+        }
+    }
+
     if let Err(resp) = require_bucket(&db, &bucket) { return Ok(resp); }
 
-    info!("S3 PutObject: bucket={} key={} user={}", bucket, key, auth_result.user_id);
+    info!("S3 PutObject: bucket={} key={} user={}", bucket, key, owner_id);
 
-    let context = UserContext::with_bucket(auth_result.user_id.clone(), auth_result.bucket.clone());
+    let context = UserContext::with_bucket(owner_id.clone(), auth_result.bucket.clone());
 
     let if_match_put = req.headers().get("if-match")
         .and_then(|v| v.to_str().ok()).map(|s| s.trim().to_string());
@@ -276,6 +300,19 @@ pub async fn s3_put_object_handler(
         );
     }
 
+    // Only store an ACL row when the request actually specifies one — otherwise the
+    // ACL handlers synthesize the private-owner-only default at read time.
+    let has_acl_header = req.headers().contains_key("x-amz-acl")
+        || ["x-amz-grant-read", "x-amz-grant-write", "x-amz-grant-read-acp", "x-amz-grant-write-acp", "x-amz-grant-full-control"]
+            .iter().any(|h| req.headers().contains_key(*h));
+    if has_acl_header {
+        let owner_display = if owner_id == ADMIN_USER_ID { crate::s3::auth::admin_display_name() } else { auth_result.owner_display_name.clone() };
+        match resolve_effective_grants(&req, None, &owner_id, &owner_display) {
+            Ok(grants) => db.set_object_acl(&bucket, &key, effective_vid, &owner_id, &grants_to_json(&grants))?,
+            Err(resp) => return Ok(resp),
+        }
+    }
+
     debug!("S3 PutObject OK: bucket={} key={} size={} etag={}", bucket, key, size, etag);
     let mut resp = HttpResponse::Ok();
     resp.insert_header(("ETag", etag));
@@ -322,7 +359,7 @@ pub async fn s3_get_object_handler(
         return s3_get_object_version_handler(&bucket, &key, vid, &req).await;
     }
     if qmap.contains_key("acl") {
-        return s3_get_object_acl_stub(&bucket, &key, &req).await;
+        return s3_get_object_acl_inner(&bucket, &key, &req).await;
     }
     if let Some(pn_str) = qmap.get("partNumber") {
         let pn: i32 = match pn_str.parse::<i32>() {
@@ -336,10 +373,26 @@ pub async fn s3_get_object_handler(
 
     if let Err(resp) = validate_object_key(&key, &bucket) { return Ok(resp); }
 
-    let auth_result = authenticate_s3_request(&req).await?;
+    let auth_result = authenticate_s3_request_allow_anonymous(&req).await?;
     let _authenticated_req = create_authenticated_request(&req, &auth_result);
 
-    let db = MetadataService::new(&auth_result.user_id)?;
+    let owner_id = if auth_result.is_anonymous { ADMIN_USER_ID.to_string() } else { auth_result.user_id.clone() };
+    let db = MetadataService::new(&owner_id)?;
+
+    if auth_result.is_anonymous {
+        // Object read permission comes from the object's own ACL, independent of the
+        // bucket's — a private bucket can still have an individually public-read object.
+        // Checked *before* bucket/key existence so a nonexistent bucket/object doesn't
+        // leak via a 404 — anonymous requests get a flat 403, same as real S3.
+        let readable = match db.get_object_acl(&bucket, &key, "") {
+            Ok(Some((_, grants_json))) => is_publicly_readable(&grants_from_json(&grants_json)),
+            _ => false,
+        };
+        if !readable {
+            return Ok(s3_error(StatusCode::FORBIDDEN, "AccessDenied", "Access Denied", &format!("/{}/{}", bucket, key)));
+        }
+    }
+
     if let Err(resp) = require_bucket(&db, &bucket) { return Ok(resp); }
 
     if !db.check_key(&bucket, &key)? {
@@ -421,7 +474,7 @@ pub async fn s3_get_object_handler(
 
     let slices = Arc::new(slices);
     let store = StorageConfig::from_env().create_store();
-    let context = UserContext::with_bucket(auth_result.user_id.clone(), auth_result.bucket.clone());
+    let context = UserContext::with_bucket(owner_id.clone(), auth_result.bucket.clone());
     let bucket_log = bucket.clone();
     let key_log = key.clone();
 
@@ -462,7 +515,8 @@ pub async fn s3_get_object_handler(
     let resp_content_encoding = qmap.get("response-content-encoding").cloned()
         .or_else(|| meta.content_encoding.clone());
 
-    let status = if range_header.is_some() { StatusCode::PARTIAL_CONTENT } else { StatusCode::OK };
+    let is_ranged = range_header.is_some();
+    let status = if is_ranged { StatusCode::PARTIAL_CONTENT } else { StatusCode::OK };
     let mut resp = HttpResponse::build(status);
     resp.content_type(resp_content_type.as_str());
     resp.insert_header(("Content-Length", response_len.to_string()));
@@ -495,10 +549,13 @@ pub async fn s3_get_object_handler(
     if let Some(ref vid) = meta.version_id {
         resp.insert_header(("x-amz-version-id", vid.clone()));
     }
-    // Return checksum headers when x-amz-checksum-mode: ENABLED
+    // Return checksum headers when x-amz-checksum-mode: ENABLED. A stored checksum
+    // covers the whole object, so it can't validate a partial (ranged) body — real S3
+    // omits it in that case, and clients like botocore auto-validate it against the
+    // response body when present, so echoing it here breaks Range GETs.
     let checksum_mode = req.headers().get("x-amz-checksum-mode")
         .and_then(|v| v.to_str().ok()).map(|s| s.to_uppercase());
-    if checksum_mode.as_deref() == Some("ENABLED") {
+    if !is_ranged && checksum_mode.as_deref() == Some("ENABLED") {
         if let (Some(ref algo_str), Some(ref cksum_val)) = (&meta.checksum_algorithm, &meta.checksum_value) {
             if let Some(algo) = ChecksumAlgorithm::from_str(algo_str) {
                 let header_name = format!("x-amz-checksum-{}", algo.header_suffix());
@@ -557,9 +614,21 @@ pub async fn s3_head_object_handler(
 
     if let Err(resp) = validate_object_key(&key, &bucket) { return Ok(resp); }
 
-    let auth_result = authenticate_s3_request(&req).await?;
+    let auth_result = authenticate_s3_request_allow_anonymous(&req).await?;
 
-    let db = MetadataService::new(&auth_result.user_id)?;
+    let owner_id = if auth_result.is_anonymous { ADMIN_USER_ID.to_string() } else { auth_result.user_id.clone() };
+    let db = MetadataService::new(&owner_id)?;
+
+    if auth_result.is_anonymous {
+        let readable = match db.get_object_acl(&bucket, &key, "") {
+            Ok(Some((_, grants_json))) => is_publicly_readable(&grants_from_json(&grants_json)),
+            _ => false,
+        };
+        if !readable {
+            return Ok(s3_error(StatusCode::FORBIDDEN, "AccessDenied", "Access Denied", &format!("/{}/{}", bucket, key)));
+        }
+    }
+
     if let Err(resp) = require_bucket(&db, &bucket) { return Ok(resp); }
 
     if !db.check_key(&bucket, &key)? {
@@ -670,7 +739,7 @@ pub async fn s3_delete_object_handler(
     let has_auth = req.headers().contains_key("authorization")
         || req.query_string().contains("X-Amz-Signature");
     if !has_auth {
-        if let Ok(db) = MetadataService::new("admin") {
+        if let Ok(db) = MetadataService::new(ADMIN_USER_ID) {
             if matches!(db.bucket_exists(&bucket), Ok(false)) {
                 return Ok(s3_error(StatusCode::NOT_FOUND, "NoSuchBucket",
                                    "The specified bucket does not exist", &bucket));

--- a/server/src/s3/handlers/versioning.rs
+++ b/server/src/s3/handlers/versioning.rs
@@ -180,6 +180,7 @@ pub(super) async fn s3_list_object_versions_handler_inner(bucket: &str, req: &Ht
     let prefix           = query.get("prefix").cloned().unwrap_or_default();
     let delimiter        = query.get("delimiter").cloned().unwrap_or_default();
     let owner_id         = xml_escape(&auth_result.user_id);
+    let owner_display    = xml_escape(&auth_result.owner_display_name);
 
     log::info!("S3 ListObjectVersions: bucket={}", bucket);
 
@@ -210,13 +211,14 @@ pub(super) async fn s3_list_object_versions_handler_inner(bucket: &str, req: &Ht
                  \t<VersionId>{vid}</VersionId>\n\
                  \t<IsLatest>{latest}</IsLatest>\n\
                  \t<LastModified>{lm}</LastModified>\n\
-                 \t<Owner><ID>{owner}</ID><DisplayName>{owner}</DisplayName></Owner>\n\
+                 \t<Owner><ID>{owner}</ID><DisplayName>{owner_dn}</DisplayName></Owner>\n\
                  \t</DeleteMarker>\n",
-                key    = xml_escape(&row.key),
-                vid    = xml_escape(display_vid),
-                latest = row.is_latest,
-                lm     = xml_escape(&row.last_modified),
-                owner  = owner_id,
+                key      = xml_escape(&row.key),
+                vid      = xml_escape(display_vid),
+                latest   = row.is_latest,
+                lm       = xml_escape(&row.last_modified),
+                owner    = owner_id,
+                owner_dn = owner_display,
             ));
         } else {
             versions_xml.push_str(&format!(
@@ -228,15 +230,16 @@ pub(super) async fn s3_list_object_versions_handler_inner(bucket: &str, req: &Ht
                  \t<ETag>&quot;{etag}&quot;</ETag>\n\
                  \t<Size>{size}</Size>\n\
                  \t<StorageClass>STANDARD</StorageClass>\n\
-                 \t<Owner><ID>{owner}</ID><DisplayName>{owner}</DisplayName></Owner>\n\
+                 \t<Owner><ID>{owner}</ID><DisplayName>{owner_dn}</DisplayName></Owner>\n\
                  \t</Version>\n",
-                key    = xml_escape(&row.key),
-                vid    = xml_escape(display_vid),
-                latest = row.is_latest,
-                lm     = xml_escape(&row.last_modified),
-                etag   = etag_bare,
-                size   = row.size,
-                owner  = owner_id,
+                key      = xml_escape(&row.key),
+                vid      = xml_escape(display_vid),
+                latest   = row.is_latest,
+                lm       = xml_escape(&row.last_modified),
+                etag     = etag_bare,
+                size     = row.size,
+                owner    = owner_id,
+                owner_dn = owner_display,
             ));
         }
     }

--- a/server/src/service/metadata_service.rs
+++ b/server/src/service/metadata_service.rs
@@ -268,6 +268,43 @@ impl MetadataService {
         SQLiteMetadataStore::new().get_multipart_tagging(upload_id)
     }
 
+    // --- ACL ---
+
+    pub fn set_bucket_acl(&self, bucket: &str, owner_id: &str, grants_json: &str) -> Result<(), Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().set_bucket_acl(bucket, owner_id, grants_json)
+    }
+
+    pub fn get_bucket_acl(&self, bucket: &str) -> Result<Option<(String, String)>, Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().get_bucket_acl(bucket)
+    }
+
+    pub fn set_object_acl(&self, bucket: &str, key: &str, version_id: &str, owner_id: &str, grants_json: &str) -> Result<(), Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().set_object_acl(bucket, key, version_id, owner_id, grants_json)
+    }
+
+    pub fn get_object_acl(&self, bucket: &str, key: &str, version_id: &str) -> Result<Option<(String, String)>, Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().get_object_acl(bucket, key, version_id)
+    }
+
+    pub fn set_public_access_block(&self, bucket: &str, block_public_acls: bool, ignore_public_acls: bool, block_public_policy: bool, restrict_public_buckets: bool) -> Result<(), Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().set_public_access_block(bucket, block_public_acls, ignore_public_acls, block_public_policy, restrict_public_buckets)
+    }
+
+    pub fn get_public_access_block(&self, bucket: &str) -> Result<Option<(bool, bool, bool, bool)>, Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().get_public_access_block(bucket)
+    }
+
+    pub fn delete_public_access_block(&self, bucket: &str) -> Result<(), Error> {
+        use crate::metadata::sqlite_store::SQLiteMetadataStore;
+        SQLiteMetadataStore::new().delete_public_access_block(bucket)
+    }
+
     // --- Multipart upload management ---
 
     pub fn create_multipart_upload(

--- a/server/tests/s3_integration.rs
+++ b/server/tests/s3_integration.rs
@@ -148,9 +148,9 @@ async fn test_s3_authentication_invalid() {
 
     let resp = test::call_service(&app, req).await;
     println!("Invalid Auth Response status: {:?}", resp.status());
-    
-    // Should return 401 Unauthorized
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    // S3 returns 403 AccessDenied (not 401) for an unrecognized access key
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 /// Test S3 authentication with missing authorization header
@@ -191,9 +191,9 @@ async fn test_s3_bucket_mismatch() {
 
     let resp = test::call_service(&app, req).await;
     println!("Bucket Mismatch Response status: {:?}", resp.status());
-    
-    // Should return 401 Unauthorized due to bucket mismatch
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+    // Unrecognized access key with no Console configured — S3 returns 403 AccessDenied
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 }
 
 /// Test S3 with curl-like requests
@@ -246,9 +246,10 @@ async fn test_s3_curl_simulation() {
 
 // --- Console / SigV4 auth integration tests ---
 
-/// When VITALITY_CONSOLE_URL is set but WARPDRIVE_SERVICE_SECRET is not set, auth fails with 401 (invalid configuration).
+/// When VITALITY_CONSOLE_URL is set but WARPDRIVE_SERVICE_SECRET is not set, auth fails with
+/// 403 AccessDenied (invalid configuration) — matching S3's auth-failure status code.
 #[actix_web::test]
-async fn test_s3_console_url_without_service_secret_returns_401() {
+async fn test_s3_console_url_without_service_secret_returns_403() {
     let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     std::env::set_var("VITALITY_CONSOLE_URL", "http://localhost:9999");
     std::env::remove_var("WARPDRIVE_SERVICE_SECRET");
@@ -264,7 +265,7 @@ async fn test_s3_console_url_without_service_secret_returns_401() {
         .to_request();
 
     let resp = test::call_service(&app, req).await;
-    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
     std::env::remove_var("VITALITY_CONSOLE_URL");
 }


### PR DESCRIPTION
Implements canned ACLs, x-amz-grant-* headers, arbitrary AccessControlPolicy XML bodies, Block Public Access, and genuine anonymous GET/HEAD/PUT/List access gated on stored ACLs, all resolved against the current static admin identity so only auth/policy routing needs to change once Vitality Console (UAM) is connected.

Also fixes two regressions found while verifying against the full Ceph suite: GetObject was echoing the whole-object checksum on ranged responses (botocore validates it against the partial body and rejects it), and bucket-name validation didn't reject IPv4-shaped names or adjacent .-/-. sequences, letting a bad bucket persist and pollute later listing tests.